### PR TITLE
feat(console): technical SEO, a real served document, and explainer pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,11 @@ jobs:
           VITE_CITECHECK_API_URL: ${{ vars.VITE_API_BASE_URL_CITECHECK }}
           VITE_LUMIOGUARD_APP_URL: ${{ vars.VITE_LUMIOGUARD_APP_URL }}
           VITE_LUMIOGUARD_SITE_URL: ${{ vars.VITE_LUMIOGUARD_SITE_URL }}
+          # Where this deployment answers. Unset, the build still succeeds and
+          # ships with no canonical, no OpenGraph URL and no sitemap, saying so
+          # on stderr. That is right for a fork and wrong for us, so the
+          # variable is set on this repo.
+          VITE_PUBLIC_SITE_URL: ${{ vars.VITE_PUBLIC_SITE_URL }}
         run: pnpm --filter @lumioguard/console run build
 
       - run: pnpm --filter @lumioguard/console run deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ the old number down.
 
 ### Added
 
+- **Readout now serves a real document.** The console shipped
+  `<div id="root"></div>` and nothing else, which Citecheck, in this repo,
+  calls `access.shell` and ranks a blocker: measured with its own engine the
+  console scored 40, the bottom band, on itself. `#root` is now filled at build
+  time from the same copy the app renders, and it scores 100. A tool that
+  reports this on other people's sites cannot ship it on its own.
+- Technical SEO for the console: a canonical, OpenGraph and Twitter cards, a
+  JSON-LD graph naming the publisher, `robots.txt`, `sitemap.xml`, `llms.txt`
+  and cache headers. All of it is generated from one source, so the served
+  document, the structured data and the picker cannot disagree.
+- Four prerendered explainer pages beside the app, and a page publishing the
+  three band ladders and what they were calibrated against. The app is one
+  screen with a URL bar on it, which is nothing for a search engine to rank.
+  They carry no meter: the consolidated verdict stays on the one surface.
 - **Citecheck**, a third tool: what stops an answer engine reading a site and
   quoting it. Empty-without-JavaScript pages, crawlers turned away, no
   machine-readable claims, nothing an answer could be lifted from.
@@ -32,6 +46,14 @@ the old number down.
 
 ### Changed
 
+- Every Worker now answers with `X-Robots-Tag: noindex`. Each answers on its own
+  public origin and `/api/scan?url=…` returns JSON about somebody else's site;
+  indexed, those are pages about other people's domains published under ours.
+  The response headers moved to `api-core` at the same time, because they were
+  written out in all three Workers and a header added to two of them is one the
+  third quietly does without.
+- The console's favicon is Readout's own mark. It was still Leakpeek's, with
+  `<title>Leakpeek</title>` inside it.
 - **BREAKING: every score now runs 0-100 where HIGHER IS BETTER.** It ran the
   other way in all three tools, while the app they hand off to has always scored
   higher-is-better; two directions in one product is a reader asking which way

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,9 @@ same change when behaviour moves.
   readable claims, nothing an answer can be lifted from. See
   `tools/citecheck/README.md`.
 
-## The five that must not break
+## The six that must not break
 
-Everything else in this file is guidance. These five are the ones where breaking
+Everything else in this file is guidance. These six are the ones where breaking
 them looks like nothing is wrong.
 
 1. **The console never imports `core`.** That ships a whole detection engine to
@@ -45,11 +45,23 @@ them looks like nothing is wrong.
 5. **A report must not become the leak.** Evidence is redacted where it is
    produced: row counts and column names, never values; keys masked. Reports
    render on sites the reader does not own.
+6. **The console serves a real document.** `#root` is filled at build time with
+   the home page's own words, taken from `src/copy.ts` and the tool catalogue.
+   Served empty it is `access.shell`, the blocker Citecheck ships in this repo,
+   and the app looks perfect to every human who visits while scoring 40 on
+   itself. Never hand-write that copy into `index.html`, and never hide the
+   static document from anything that runs JavaScript: serving one thing to a
+   browser and another to a crawler is the cloaking these tools report.
 
 ## Layout
 
 ```
 apps/console                    the one front end
+  build/                        what a crawler is served, written at build time
+  build/pages/                  the prerendered explainers, one document each
+  src/copy.ts                   the app's own words, read by the app and the build
+  src/pages.ts                  the explainers, registered for the app and the build
+  src/tools/catalogue.ts        each tool's id, label and summary as plain data
   src/tools/registry.ts         what a tool must provide to appear
   src/tools/<tool>/             its client, report panels, ink and descriptor
 packages/shared                 wire contracts (zod) and shared domain vocabulary
@@ -215,7 +227,7 @@ no-script render must already be correct.
 
 ## Security
 
-Beyond the five invariants above:
+Beyond the six invariants above:
 
 - Errors from internals are answered generically. Their messages carry file paths
   and rule source.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,11 @@ fixtures to make it pass.
    `/<name>/api` to it with no edit anywhere.
 3. Add a descriptor in `apps/console/src/tools/` and a line in that folder's
    `index.ts`. That is the whole surface change: the picker, the consolidated
-   score, the hand-off and the report all read that array.
+   score, the hand-off and the report all read that array. Its `id`, `label` and
+   `summary` are spread from `catalogue.ts`, which is the same list the served
+   document and the structured data are written from, so a new reading appears
+   to a crawler and to a visitor at once. `catalogue.test.ts` holds the two
+   lists to the same order.
 4. Add the tool to the `tool` choice list in `.github/workflows/deploy.yml`.
 5. Add `VITE_API_BASE_URL_<TOOL>` as a repository variable and map it to the
    console's `VITE_<NAME>_API_URL` in the console build step.
@@ -209,6 +213,95 @@ pnpm dlx wrangler rollback --name lumioguard-<tool>-api
 
 Pages rollback is done from the dashboard: pick a previous deployment and promote
 it to production.
+
+## What the console serves to a crawler
+
+The console is a single-page app, and for most of its life the document it
+served was `<div id="root"></div>` and nothing else. Citecheck, which ships in
+this repo, calls that `access.shell` and ranks it a **blocker**: one blocker
+pins a page into the bottom band whatever else is true of it. Measured with the
+engine in `tools/citecheck/core`, the console scored **40, Unreadable** on
+itself. It now scores **100, Legible**.
+
+`apps/console/build/` is what changed it, and it runs in `pnpm dev` as well as
+in `pnpm build`, so what you check locally is what ships:
+
+| File | What it writes |
+|---|---|
+| `head.ts` | The `<head>` metadata and the JSON-LD, per page |
+| `shell.ts` | The static document that fills `#root` on the app |
+| `pages/content.ts` | The explainers' prose, and the ladders read from `shared` |
+| `pages/render.ts` | One explainer to a complete standalone document |
+| `wellKnown.ts` | `robots.txt`, `sitemap.xml`, `llms.txt` |
+| `site.ts` | Reads `VITE_PUBLIC_SITE_URL` and refuses a malformed one |
+| `seo.ts` | The Vite plugin wiring them together |
+
+### The explainer pages
+
+The app is one screen with a URL bar on it, which is nothing for a search
+engine to rank: 64 words, one heading, one URL. `src/pages.ts` registers a set
+of explainers that give it something to be found for, and
+`build/pages/content.ts` pairs each entry with its prose the same way the tool
+descriptors pair with the catalogue.
+
+They are **prerendered documents, not app routes**. No React, no meter: the
+consolidated verdict stays on the one surface, and every page links back into
+it. Four things about them are load-bearing.
+
+**They are emitted as `<slug>.html`, never `<slug>/index.html`.** Cloudflare
+Pages answers `/slug` from `/slug.html` with a 200, and answers it from
+`/slug/index.html` with a **308 to `/slug/`**. Under the second shape every
+canonical, sitemap entry and internal link points at a URL that moves. Verify
+with the real thing, because `vite preview` masks it by falling back to the
+app's `index.html` for any unknown path:
+
+```bash
+pnpm --filter @lumioguard/console exec wrangler pages dev dist
+```
+
+**Every published number is read from `shared`.** The band tables on
+`/how-the-scores-work` come from `CITATION_BANDS`, `EXPOSURE_BANDS` and
+`TIER_BANDS`, so retuning a ladder moves the published table the same day it
+moves the score.
+
+**`content.ts` imports `shared` by a relative path on purpose.** It is reached
+from `vite.config.ts`, which Vite bundles with esbuild before any alias exists.
+A bare `@lumioguard/shared` is left external, Node then loads the package's own
+entry, and that entry is TypeScript source. The build dies with `Unknown file
+extension ".ts"`. The comment on the import says so; do not tidy it back.
+
+**The links live in the React colophon too.** A crawler that runs JavaScript
+sees what React rendered, so a link carried only by the prerendered shell is one
+Google never follows.
+
+Three things about it are load-bearing.
+
+**Every word is imported.** The heading, the description and the three beats
+come from `src/copy.ts`; the readings come from `src/tools/catalogue.ts`, which
+is also what the descriptors spread their `label` and `summary` from. Typed out
+twice, the served document could say something the app does not, and a page
+whose served text differs from what a reader sees is what `access.agent-thin`
+reports. Do not hand-write copy into `index.html`.
+
+**React clears `#root` on its first commit**, so the static document is what the
+page is until the app mounts and never after. It is not a fallback that lingers,
+and it is not hidden by script: hiding it from anything that runs JavaScript
+while serving it to anything that does not is cloaking, and Citecheck has a rule
+for that too.
+
+**The origin is not baked in.** With `VITE_PUBLIC_SITE_URL` unset there is no
+canonical, no OpenGraph URL and no sitemap, and the build says so on stderr. A
+fork must not ship a canonical pointing at our host, which is
+`document.foreign-canonical`, another blocker. Set the variable, or accept that
+what you deploy carries none of it.
+
+To check a change, build and read the engine's own verdict rather than trusting
+the markup:
+
+```bash
+VITE_PUBLIC_SITE_URL=https://example.test pnpm --filter @lumioguard/console run build
+cat apps/console/dist/index.html apps/console/dist/robots.txt
+```
 
 ## Local environment files
 

--- a/apps/console/.env.example
+++ b/apps/console/.env.example
@@ -29,3 +29,18 @@
 # colophon is a credit and belongs on the page that says what LumioGuard is.
 # Falls back to the app URL when unset.
 # VITE_LUMIOGUARD_SITE_URL=https://lumioguard.dev
+
+# ---------------------------------------------------------------------------
+# Where this deployment answers, as a bare origin with no path.
+#
+# The canonical, the OpenGraph URL, the structured data, sitemap.xml and the
+# `Sitemap:` line in robots.txt are all absolute by definition, so none of them
+# can be written without this. UNSET means every one of them is omitted and the
+# build says so on stderr.
+#
+# There is no address baked in to fall back to, for the same reason the hand-off
+# has none: a fork that deployed this would otherwise ship a canonical pointing
+# at somebody else's host, which is `document.foreign-canonical`, a blocker in
+# the tool this app ships.
+# ---------------------------------------------------------------------------
+# VITE_PUBLIC_SITE_URL=https://lumioguard-readout.pages.dev

--- a/apps/console/build/__tests__/head.test.ts
+++ b/apps/console/build/__tests__/head.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { DESCRIPTION, NAME, TITLE } from '../../src/copy.js';
+import { CATALOGUE } from '../../src/tools/catalogue.js';
+import { HOME, headTags } from '../head.js';
+
+const ORIGIN = 'https://example.test';
+
+describe('headTags', () => {
+  it('writes nothing absolute without an origin', () => {
+    // A wrong canonical hands the page's standing to another address, so the
+    // absent case writes none of it rather than guessing.
+    const tags = headTags(HOME, null, true);
+    expect(tags).not.toContain('rel="canonical"');
+    expect(tags).not.toContain('og:url');
+    expect(tags).not.toContain('ld+json');
+  });
+
+  it('still says what the page is without an origin', () => {
+    const tags = headTags(HOME, null, false);
+    expect(tags).toContain(`<title>${TITLE}</title>`);
+    expect(tags).toContain(DESCRIPTION);
+    expect(tags).toContain('og:title');
+  });
+
+  it('points the canonical at the home document, not at whatever ?site= is set', () => {
+    expect(headTags(HOME, ORIGIN, true)).toContain(`<link rel="canonical" href="${ORIGIN}/" />`);
+  });
+
+  it('drops every image tag together when there is no image', () => {
+    const tags = headTags(HOME, ORIGIN, false);
+    expect(tags).not.toContain('og:image');
+    expect(tags).not.toContain('twitter:image');
+    // Claiming the large card with no picture renders an empty box.
+    expect(tags).toContain('name="twitter:card" content="summary"');
+  });
+});
+
+describe('the structured data', () => {
+  const block = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/.exec(
+    headTags(HOME, ORIGIN, true),
+  );
+  const graph = JSON.parse((block?.[1] ?? '{}').replace(/\\u003c/g, '<')) as {
+    readonly '@graph': readonly { readonly '@type': string; readonly featureList?: string[] }[];
+  };
+
+  it('parses, which is the whole of what a consumer checks', () => {
+    // `structured.invalid` is major precisely because nothing reports a block
+    // it could not read: the markup looks present and counts for nothing.
+    expect(graph['@graph'].length).toBeGreaterThan(0);
+  });
+
+  it('names who publishes this', () => {
+    // `structured.no-entity`: an engine has to resolve who a page is about
+    // before it can attribute anything to them.
+    expect(graph['@graph'].map((node) => node['@type'])).toContain('Organization');
+  });
+
+  it('lists the readings from the catalogue rather than a copy of it', () => {
+    const app = graph['@graph'].find((node) => node['@type'] === 'WebApplication');
+    expect(app?.featureList).toHaveLength(CATALOGUE.length);
+    for (const tool of CATALOGUE) {
+      expect(app?.featureList?.join(' ')).toContain(tool.label);
+    }
+  });
+
+  it('escapes the one character that would close the script early', () => {
+    expect(block?.[1]).not.toContain('<');
+  });
+});
+
+describe('the copy the head is built from', () => {
+  it('keeps the description inside what a search result will show', () => {
+    // Citecheck's own floor is 25 characters and nothing here approaches it.
+    // The ceiling is the one that bites, and it is a truncated snippet rather
+    // than a finding anywhere.
+    expect(DESCRIPTION.length).toBeLessThanOrEqual(160);
+  });
+
+  it('keeps the title inside what a search result will show', () => {
+    // `document.long-title` fires past 75, set where there is no width at
+    // which a title still fits.
+    expect(TITLE.length).toBeLessThanOrEqual(75);
+  });
+
+  it('names the app in its own title', () => {
+    expect(TITLE).toContain(NAME);
+  });
+});

--- a/apps/console/build/__tests__/pages.test.ts
+++ b/apps/console/build/__tests__/pages.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { PAGES } from '../../src/pages.js';
+import { CONTENT_PAGES } from '../pages/content.js';
+import { renderPage } from '../pages/render.js';
+
+const ORIGIN = 'https://example.test';
+
+/**
+ * The explainers exist to be findable, so what is asserted here is the things
+ * that decide whether they can be: one heading each, real prose, links out, and
+ * metadata that does not collide with another page's.
+ */
+
+describe('the page register', () => {
+  it('has prose for every registered page, and no page without a link', () => {
+    expect(CONTENT_PAGES.map((page) => page.meta.path)).toEqual(PAGES.map((page) => page.path));
+  });
+
+  it('gives every page a rooted path, which is what the emitted file is named from', () => {
+    for (const page of PAGES) {
+      expect(page.path.startsWith('/'), `${page.path} is not rooted`).toBe(true);
+      expect(page.path.endsWith('/'), `${page.path} has a trailing slash`).toBe(false);
+    }
+  });
+
+  it('gives every page its own title and description', () => {
+    // Two pages sharing either is `document.duplicate-title`, and a search
+    // engine picking between them picks one and drops the other.
+    expect(new Set(PAGES.map((page) => page.title)).size).toBe(PAGES.length);
+    expect(new Set(PAGES.map((page) => page.description)).size).toBe(PAGES.length);
+  });
+
+  it('keeps every title and description inside what a search result shows', () => {
+    for (const page of PAGES) {
+      expect(page.title.length, `${page.path} title`).toBeLessThanOrEqual(75);
+      expect(page.description.length, `${page.path} description`).toBeGreaterThanOrEqual(25);
+    }
+  });
+});
+
+describe('a rendered page', () => {
+  for (const page of CONTENT_PAGES) {
+    describe(page.meta.path, () => {
+      const html = renderPage(page, ORIGIN, true);
+
+      it('has exactly one h1, and it is the title', () => {
+        // `document.many-h1` and `document.no-h1` both sit on this.
+        const h1 = [...html.matchAll(/<h1>([\s\S]*?)<\/h1>/g)];
+        expect(h1).toHaveLength(1);
+        expect(h1[0]?.[1]).toContain(page.meta.title.replace(/&/g, '&amp;'));
+      });
+
+      it('carries enough prose to be worth reading', () => {
+        const words = html
+          .replace(/<(style|script)[\s\S]*?<\/\1>/g, ' ')
+          .replace(/<[^>]+>/g, ' ')
+          .trim()
+          .split(/\s+/);
+        expect(words.length, `${page.meta.path} is thin`).toBeGreaterThan(300);
+      });
+
+      it('declares its language, and its own canonical', () => {
+        expect(html).toContain('<html lang="en">');
+        expect(html).toContain(`<link rel="canonical" href="${ORIGIN}${page.meta.path}" />`);
+      });
+
+      it('links back to the app and out to its siblings', () => {
+        expect(html).toContain('href="/"');
+        for (const sibling of PAGES) {
+          if (sibling.path === page.meta.path) continue;
+          expect(html, `no link to ${sibling.path}`).toContain(`href="${sibling.path}"`);
+        }
+      });
+
+      it('carries no meter, because the verdict lives on one surface', () => {
+        expect(html).not.toContain('/ 100');
+        expect(html).not.toMatch(/\bscore\b\s*[:=]/i);
+      });
+
+      it('escapes markup rather than emitting it', () => {
+        expect(html).not.toMatch(/&(?![a-z]+;|#\d+;)/i);
+      });
+    });
+  }
+});
+
+describe('the published ladders', () => {
+  const scores = CONTENT_PAGES.find((page) => page.meta.path === '/how-the-scores-work');
+
+  it('are read from the constants, so a retuned band moves the page with it', () => {
+    const tables = (scores?.sections ?? []).flatMap((section) =>
+      section.table === undefined ? [] : [section.table],
+    );
+    expect(tables.length).toBeGreaterThanOrEqual(3);
+    for (const table of tables) {
+      // Four bands apiece, every row a band name, a range and a meaning.
+      expect(table.rows).toHaveLength(4);
+      for (const row of table.rows) expect(row).toHaveLength(table.head.length);
+    }
+  });
+
+  it('names a range that ends at the top of the scale', () => {
+    const table = (scores?.sections ?? []).flatMap((s) => (s.table ? [s.table] : []))[0];
+    expect(table?.rows[0]?.[1]).toMatch(/-100$/);
+  });
+});

--- a/apps/console/build/__tests__/shell.test.ts
+++ b/apps/console/build/__tests__/shell.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { DESCRIPTION, EXAMPLES, HEADLINE_TEXT } from '../../src/copy.js';
+import { CATALOGUE } from '../../src/tools/catalogue.js';
+import { staticShell } from '../shell.js';
+
+/**
+ * Asserted as properties of the markup, never by running Citecheck over it: the
+ * console may not import a detection engine, and a test is still the console.
+ * The rules these stand in for are named where they are not obvious.
+ */
+
+describe('staticShell', () => {
+  const shell = staticShell();
+
+  it('leaves the mount point holding a document rather than nothing', () => {
+    // `<div id="root"></div>`, closed and empty, is what `access.shell` matches,
+    // and one blocker pins the page into the bottom band on its own.
+    expect(`<div id="root">${shell}</div>`).not.toMatch(/<div id="root">\s*<\/div>/);
+    expect(shell).toContain('<h1>');
+  });
+
+  it('carries the heading the app renders, word for word', () => {
+    expect(shell).toContain(HEADLINE_TEXT);
+  });
+
+  it('carries the description the head tags and the structured data use', () => {
+    expect(shell).toContain(DESCRIPTION);
+  });
+
+  it('names every reading the picker offers', () => {
+    // The text a reader ends up with, not the markup: the ampersand in
+    // "SEO & AI visibility" is `&amp;` on the way through.
+    const text = shell.replace(/&amp;/g, '&');
+    for (const tool of CATALOGUE) {
+      expect(text, `${tool.id} is not in the served document`).toContain(tool.label);
+      expect(text, `${tool.id} has no summary in the served document`).toContain(tool.summary);
+    }
+  });
+
+  it('links somewhere, using addresses the app can open', () => {
+    // `document.no-links`: a page with none is one a crawler cannot leave.
+    for (const site of EXAMPLES) {
+      expect(shell).toContain(`href="/?site=${site}"`);
+    }
+  });
+
+  it('gives every link text naming where it goes', () => {
+    // `document.vague-anchors`: text saying nothing about its target.
+    const texts = [...shell.matchAll(/<a\b[^>]*>([^<]*)<\/a>/g)].map((match) => match[1] ?? '');
+    expect(texts.length).toBeGreaterThan(0);
+    for (const text of texts) {
+      expect(text.trim().length, `"${text}" is too short to say where it goes`).toBeGreaterThan(4);
+      expect(text.toLowerCase()).not.toMatch(/^(click here|here|read more|learn more|more)$/);
+    }
+  });
+
+  it('has enough prose to be a document', () => {
+    const words = shell
+      .replace(/<style>[\s\S]*?<\/style>/g, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .trim()
+      .split(/\s+/);
+    // Citecheck's floor for "no readable content at all" is 12 words of the
+    // whole body. Clearing it by an order of magnitude is the point: the shell
+    // is the page, not a placeholder that happens to pass.
+    expect(words.length).toBeGreaterThan(80);
+  });
+
+  it('escapes markup rather than emitting it', () => {
+    expect(shell).toContain('SEO &amp; AI visibility');
+    expect(shell).not.toMatch(/&(?![a-z]+;|#\d+;)/i);
+  });
+});

--- a/apps/console/build/__tests__/wellKnown.test.ts
+++ b/apps/console/build/__tests__/wellKnown.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { PAGES } from '../../src/pages.js';
+import { CATALOGUE } from '../../src/tools/catalogue.js';
+import { llmsTxt, robotsTxt, sitemapXml } from '../wellKnown.js';
+
+const ORIGIN = 'https://example.test';
+
+/**
+ * Every field a robots.txt may carry, as the major crawlers document them.
+ *
+ * Held here as well as in Citecheck's parser on purpose: this is the list a
+ * crawler enforces, and the console may not import an engine to ask it. A field
+ * outside it is skipped in silence, so the rule was never in force.
+ */
+const KNOWN_FIELDS = new Set([
+  'user-agent',
+  'disallow',
+  'allow',
+  'sitemap',
+  'crawl-delay',
+  'host',
+  'noindex',
+  'clean-param',
+  'request-rate',
+  'visit-time',
+]);
+
+describe('robots.txt', () => {
+  it('uses only fields a crawler recognises', () => {
+    for (const raw of robotsTxt(ORIGIN).split('\n')) {
+      const line = raw.replace(/#.*$/, '').trim();
+      if (line === '') continue;
+      const field = line.slice(0, line.indexOf(':')).toLowerCase();
+      expect(line, `"${line}" is not a Field: value line`).toContain(':');
+      expect(KNOWN_FIELDS.has(field), `"${field}" is a field nothing reads`).toBe(true);
+    }
+  });
+
+  it('turns nobody away', () => {
+    // `Disallow:` with no value is RFC 9309 for "all of it is yours"; blocking
+    // machines here would be the `access.llms-contradiction` pair.
+    const text = robotsTxt(ORIGIN);
+    expect(text).toContain('User-agent: *');
+    expect(text).toMatch(/^Disallow:\s*$/m);
+    expect(text).not.toMatch(/^Disallow:\s*\//m);
+  });
+
+  it('names the sitemap, so a crawler that reads this first still finds it', () => {
+    // `access.sitemap-unlisted`: crawlers guessing at /sitemap.xml find it, the
+    // ones that read robots.txt first do not look.
+    expect(robotsTxt(ORIGIN)).toContain(`Sitemap: ${ORIGIN}/sitemap.xml`);
+  });
+
+  it('omits the sitemap line rather than writing a relative one', () => {
+    // There is no relative form of Sitemap:, so with no origin there is no
+    // honest line to write.
+    expect(robotsTxt(null)).not.toContain('Sitemap:');
+    expect(robotsTxt(null)).toContain('User-agent: *');
+  });
+});
+
+describe('sitemap.xml', () => {
+  const xml = sitemapXml(ORIGIN);
+
+  it('lists the app and every explainer, and nothing else', () => {
+    // Readings are absent on purpose: they live at `?site=…` on the app and
+    // canonicalise back to it, so each would be one document under many names.
+    expect([...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1])).toEqual([
+      `${ORIGIN}/`,
+      ...PAGES.map((page) => `${ORIGIN}${page.path}`),
+    ]);
+  });
+
+  it('claims nothing it cannot know', () => {
+    // A lastmod would have to be the build time, which changes when nothing
+    // about the page did. changefreq and priority are read by nothing.
+    expect(xml).not.toContain('lastmod');
+    expect(xml).not.toContain('changefreq');
+    expect(xml).not.toContain('priority');
+  });
+
+  it('declares the namespace, without which it is not a sitemap', () => {
+    expect(xml).toContain('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"');
+  });
+});
+
+describe('llms.txt', () => {
+  const text = llmsTxt(ORIGIN);
+
+  it('opens the way the format requires: one H1, then a blockquote summary', () => {
+    const lines = text.split('\n').filter((line) => line.trim() !== '');
+    expect(lines[0]).toMatch(/^# \S/);
+    expect(lines[1]).toMatch(/^> \S/);
+  });
+
+  it('describes the readings the app actually offers', () => {
+    for (const tool of CATALOGUE) {
+      expect(text, `${tool.id} is missing`).toContain(tool.label);
+      expect(text).toContain(`/?tools=${tool.id}`);
+    }
+  });
+
+  it('falls back to relative links rather than inventing a host', () => {
+    expect(llmsTxt(null)).toContain('](/?tools=');
+  });
+});

--- a/apps/console/build/head.ts
+++ b/apps/console/build/head.ts
@@ -1,0 +1,156 @@
+import { DESCRIPTION, NAME, PUBLISHER, TITLE } from '../src/copy.js';
+import type { PageLink } from '../src/pages.js';
+import { CATALOGUE } from '../src/tools/catalogue.js';
+import { escapeHtml } from './html.js';
+import { absolute } from './site.js';
+
+/**
+ * Where the card image is emitted, and what it is a picture of. The path is
+ * derived from the file name so the tag and the emitted asset cannot name
+ * different things.
+ */
+const CARD_FILE = 'og.jpg';
+export const OG_IMAGE = {
+  file: CARD_FILE,
+  path: `/${CARD_FILE}`,
+  width: 1568,
+  height: 773,
+  alt: `${NAME} reading a site: one verdict, with each reading underneath it`,
+} as const;
+
+/**
+ * The app itself, in the shape the explainers are registered in. Every other
+ * page is an explainer that links back to it.
+ */
+export const HOME: PageLink = { path: '/', title: TITLE, description: DESCRIPTION };
+
+/**
+ * Everything in `<head>` that says what this page is, split by whether it needs
+ * the origin. `site.ts` says why the absent case writes nothing.
+ */
+export function headTags(page: PageLink, origin: string | null, hasImage: boolean): string {
+  const originless: string[] = [
+    `<title>${escapeHtml(page.title)}</title>`,
+    `<meta name="description" content="${escapeHtml(page.description)}" />`,
+    '<meta property="og:type" content="website" />',
+    `<meta property="og:site_name" content="${escapeHtml(NAME)}" />`,
+    `<meta property="og:title" content="${escapeHtml(page.title)}" />`,
+    `<meta property="og:description" content="${escapeHtml(page.description)}" />`,
+    '<meta property="og:locale" content="en" />',
+    `<meta name="twitter:card" content="${hasImage ? 'summary_large_image' : 'summary'}" />`,
+    `<meta name="twitter:title" content="${escapeHtml(page.title)}" />`,
+    `<meta name="twitter:description" content="${escapeHtml(page.description)}" />`,
+  ];
+
+  if (origin === null) return originless.join('\n    ');
+
+  const self = absolute(origin, page.path);
+  return [
+    ...originless,
+    // On the app, every reading lives at `?site=…` on this one document, so the
+    // canonical stops a crawler indexing a thin JavaScript-only variant per
+    // site anybody has ever read.
+    `<link rel="canonical" href="${escapeHtml(self)}" />`,
+    `<meta property="og:url" content="${escapeHtml(self)}" />`,
+    ...(hasImage ? imageTags(absolute(origin, OG_IMAGE.path)) : []),
+    `<script type="application/ld+json">${jsonLd(page, origin, hasImage)}</script>`,
+  ].join('\n    ');
+}
+
+/** All of them or none: a card with a broken picture is worse than a plain one. */
+function imageTags(card: string): string[] {
+  return [
+    `<meta property="og:image" content="${escapeHtml(card)}" />`,
+    `<meta property="og:image:width" content="${OG_IMAGE.width}" />`,
+    `<meta property="og:image:height" content="${OG_IMAGE.height}" />`,
+    `<meta property="og:image:alt" content="${escapeHtml(OG_IMAGE.alt)}" />`,
+    `<meta name="twitter:image" content="${escapeHtml(card)}" />`,
+    `<meta name="twitter:image:alt" content="${escapeHtml(OG_IMAGE.alt)}" />`,
+  ];
+}
+
+/**
+ * What this page is, for something that will not read the prose.
+ *
+ * The Organization node answers `structured.no-entity`: an engine resolves who
+ * a page is about before it attributes anything. Explainers are `WebPage` and
+ * not `Article` on purpose: the Article types carry a date because being dated
+ * is part of the type, and an evergreen page has no honest one to give.
+ */
+function jsonLd(page: PageLink, origin: string, hasImage: boolean): string {
+  const home = absolute(origin, '/');
+  const self = absolute(origin, page.path);
+
+  const site = [
+    { '@type': 'Organization', '@id': `${home}#publisher`, name: PUBLISHER },
+    {
+      '@type': 'WebSite',
+      '@id': `${home}#website`,
+      url: home,
+      name: NAME,
+      description: DESCRIPTION,
+      inLanguage: 'en',
+      publisher: { '@id': `${home}#publisher` },
+    },
+  ];
+
+  const graph =
+    page.path === HOME.path
+      ? [...site, application(home, hasImage ? absolute(origin, OG_IMAGE.path) : null)]
+      : [...site, explainer(page, self, home), breadcrumb(page, self, home)];
+
+  // A raw `<` cannot appear inside a script element, whatever it is a script of.
+  return JSON.stringify({ '@context': 'https://schema.org', '@graph': graph }).replace(
+    /</g,
+    '\\u003c',
+  );
+}
+
+/**
+ * The feature list is read from the catalogue, so a fourth reading appears here
+ * the day the picker gets it.
+ */
+function application(home: string, image: string | null): Record<string, unknown> {
+  return {
+    '@type': 'WebApplication',
+    '@id': `${home}#app`,
+    url: home,
+    name: NAME,
+    description: DESCRIPTION,
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Any',
+    browserRequirements: 'Requires JavaScript',
+    // The one commercial claim this repo can stand behind: there is no
+    // payment path in it. An `offers` node would assert terms nothing defines.
+    isAccessibleForFree: true,
+    inLanguage: 'en',
+    isPartOf: { '@id': `${home}#website` },
+    publisher: { '@id': `${home}#publisher` },
+    featureList: CATALOGUE.map((tool) => `${tool.label}: ${tool.summary}`),
+    ...(image === null ? {} : { image }),
+  };
+}
+
+function explainer(page: PageLink, self: string, home: string): Record<string, unknown> {
+  return {
+    '@type': 'WebPage',
+    '@id': `${self}#page`,
+    url: self,
+    name: page.title,
+    description: page.description,
+    inLanguage: 'en',
+    isPartOf: { '@id': `${home}#website` },
+    publisher: { '@id': `${home}#publisher` },
+  };
+}
+
+function breadcrumb(page: PageLink, self: string, home: string): Record<string, unknown> {
+  return {
+    '@type': 'BreadcrumbList',
+    '@id': `${self}#breadcrumb`,
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: NAME, item: home },
+      { '@type': 'ListItem', position: 2, name: page.title, item: self },
+    ],
+  };
+}

--- a/apps/console/build/html.ts
+++ b/apps/console/build/html.ts
@@ -1,0 +1,8 @@
+/** Text going into an attribute or between tags, never markup. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/apps/console/build/pages/content.ts
+++ b/apps/console/build/pages/content.ts
@@ -1,0 +1,232 @@
+// RELATIVE, not `@lumioguard/shared`, and it has to stay that way. This module
+// is reached from `vite.config.ts`, which Vite bundles with esbuild before any
+// alias exists: a bare specifier is left external, Node then loads the
+// package's own entry, and that entry is TypeScript source. The build dies with
+// `Unknown file extension ".ts"`. A relative path is bundled instead.
+import {
+  CITATION_BANDS,
+  CITATION_MAX,
+  EXPOSURE_BANDS,
+  EXPOSURE_MAX,
+  SCORE_MAX,
+  TIER_BANDS,
+} from '../../../../packages/shared/src/index.js';
+import { type PageLink, pageLink } from '../../src/pages.js';
+
+/**
+ * The explainer pages, as data.
+ *
+ * They exist because the app is one screen with a URL bar on it, which is
+ * nothing for a search engine to rank. These are prerendered documents with no
+ * meter on them: the verdict stays on the one surface, and every page here
+ * links into it.
+ *
+ * Everything numeric is read from the ladders in `shared`, never typed. A
+ * retuned band moves the published table the same day it moves the score.
+ */
+
+export interface Table {
+  readonly caption: string;
+  readonly head: readonly string[];
+  readonly rows: readonly (readonly string[])[];
+}
+
+export interface Section {
+  readonly heading: string;
+  readonly body?: readonly string[];
+  readonly list?: readonly string[];
+  readonly table?: Table;
+}
+
+export interface ContentPage {
+  readonly meta: PageLink;
+  /** The sentence under the heading, and the one an answer is lifted from. */
+  readonly lead: string;
+  readonly sections: readonly Section[];
+}
+
+interface Band {
+  readonly tier: string;
+  readonly from: number;
+  readonly to: number;
+  readonly description: string;
+}
+
+/** Best band first, and the unbounded top `to` clipped to the end of the scale. */
+function ladder(caption: string, bands: readonly Band[], max: number): Table {
+  return {
+    caption,
+    head: ['Band', 'Score', 'What it means'],
+    rows: [...bands]
+      .reverse()
+      .map((band) => [band.tier, `${band.from}-${Math.min(band.to, max)}`, band.description]),
+  };
+}
+
+const CITE: ContentPage = {
+  meta: pageLink('/can-ai-cite-your-site'),
+  lead: 'An answer engine can only quote what it can read. Most of the crawlers feeding them do not run JavaScript, so what gets stored for your URL is whatever your server sent in the first response.',
+  sections: [
+    {
+      heading: 'What a crawler actually receives',
+      body: [
+        'Open your own page, view source, and read what comes back. That text, before any script runs, is the whole of what most crawlers keep. A single-page app often sends a document containing one empty element and a script tag, and a browser fills it in a moment later. A crawler that does not run scripts never sees that moment.',
+        'This is the single most expensive thing a site can get wrong here, because it is not a matter of degree. A page that arrives empty is not quoted less often. It is not quoted.',
+      ],
+    },
+    {
+      heading: 'The four things that stop a page being quoted outright',
+      body: [
+        'These are definitional rather than measured. Each one makes citation impossible whatever else is true of the page, so no amount of good structured data underneath changes the answer.',
+      ],
+      list: [
+        'The page says noindex, so it is asking not to be in an index at all.',
+        'The served document carries no readable text without JavaScript.',
+        'The server answers a crawler user agent with 403 while serving a browser normally.',
+        'The canonical tag points at a different host, handing the page away.',
+      ],
+    },
+    {
+      heading: 'What is not a barrier, despite the advice',
+      body: [
+        'Citecheck was calibrated against pages answer engines demonstrably quote every day: Wikipedia, MDN, and the Python, React, nginx and Postgres references. The rule was that such a page must come out in the top band, because nothing is in fact standing in its way.',
+        'That corpus overturned most of a first cut made from intuition. Five of those six ship no JSON-LD at all. Four carry no meta description. Three have no canonical, and two have no h1. None of those can be a barrier to citation when the most-quoted references on the web are missing them.',
+        'So best practice is not the same as a barrier, and only the barriers are scored heavily. An absence is a choice and costs nothing. A broken attempt is a defect and keeps its weight: a canonical that will not parse, JSON-LD that will not read, an hreflang no engine recognises. Somebody meant those to work, and they do not.',
+      ],
+    },
+    {
+      heading: 'robots.txt, sitemaps and llms.txt',
+      body: [
+        'A crawler reads robots.txt before it reads a page. A mistyped field there is skipped in silence, so the rule its author wrote was never in force and nothing anywhere reports it. Naming your sitemap in robots.txt costs one line and is the difference between a crawler finding it and guessing.',
+        'llms.txt is a newer convention: a plain-text guide written for agents rather than browsers. Publishing one while separately telling most AI crawlers not to fetch anything is a contradiction, and one of the two files is stale.',
+      ],
+    },
+    {
+      heading: 'Blocking AI crawlers is a decision, not a defect',
+      body: [
+        'Nothing here scores a site for turning an agent away. That is a choice a site is entitled to make, and charging for it would be charging somebody for meaning what they said. What is worth reporting is two files the same site serves giving opposite instructions.',
+      ],
+    },
+  ],
+};
+
+const KEYS: ContentPage = {
+  meta: pageLink('/api-keys-in-frontend-code'),
+  lead: 'Everything your app ships to the browser is readable by anyone who opens it. Minification is not concealment: a bundle is a text file served to the public, and searching it takes seconds.',
+  sections: [
+    {
+      heading: 'Not every key in a bundle is a problem',
+      body: [
+        'This is the distinction that matters most, and the one most checklists get wrong. Some keys are designed to be public. A Supabase anon key, a Stripe publishable key, a Firebase web config: these are meant to ship, and finding one in a bundle is not by itself a finding.',
+        'What makes them safe is what stands behind them. An anon key is safe because row-level security decides what it can read. Turn that off and the same key is a public read of your database. The key was never the control. The policy was.',
+      ],
+    },
+    {
+      heading: 'The keys that are always a problem',
+      body: [
+        'A service key is the opposite kind of object. It is designed to bypass policy, which is exactly why it must never reach a browser. A service_role key in a client bundle is not a misconfiguration to schedule, it is a live credential published to everyone who loads the page.',
+      ],
+    },
+    {
+      heading: 'Things that are served without anybody deciding to serve them',
+      body: [
+        'Most exposure is not a decision. It is a default nobody turned off, or a file that ended up inside the directory the web server publishes.',
+      ],
+      list: [
+        'Source maps in production, which republish your original source alongside the bundle.',
+        'A .env file inside the web root, readable at its own URL.',
+        'A .git directory served as static files, from which the repository can be reconstructed.',
+        'A database table that answers an unauthenticated read.',
+      ],
+    },
+    {
+      heading: 'Assessing a hole is not the same as opening one',
+      body: [
+        'A reading of a site should never change it. Leakpeek is GET only, through one request primitive, with no code path that writes. Where a finding could only be proven by writing, it is reported as unverified rather than proven.',
+        'Evidence is redacted where it is produced, too. A readable table is reported as a row count and column names, never values, and a key is masked. A report gets read on sites the reader does not own, and a report that quotes the secret back has become the leak.',
+      ],
+    },
+  ],
+};
+
+const SLOP: ContentPage = {
+  meta: pageLink('/what-ai-slop-looks-like'),
+  lead: 'Generated sites converge. Not because generation is bad, but because every generator reaches for the same defaults, and the defaults are recognisable once you know them.',
+  sections: [
+    {
+      heading: 'The tells are specific, not a vibe',
+      body: [
+        'Slopmeter scores how closely a site matches the defaults generated sites ship with. It reads the page rather than judging it, so every signal is something you can go and look at.',
+      ],
+      list: [
+        'A hero line straight from the template, and copy written in clipped slogans.',
+        'The vocabulary chatbots reach for, and the it-is-not-just-X-it-is-Y construction.',
+        'Stiff connectors: moreover, furthermore. Filler phrases that say nothing.',
+        'A bento grid, cards inside cards, and a trusted-by logo row with nothing behind it.',
+        'Coloured glows instead of shadows, text filled with a gradient, graph-paper grids.',
+        'Rounded icon tiles stacked above headings, and tiny all-caps labels above them.',
+        'The default icon set untouched, stock component-library theme values, one of the handful of fonts everything uses.',
+        'Body text set too tight or too small to read comfortably.',
+      ],
+    },
+    {
+      heading: 'Why it is worth knowing',
+      body: [
+        'A templated page is not ugly. It is unspecific. Every choice it did not make is a thing it does not say about you, and a visitor who has seen forty pages like it has no reason to remember the forty-first.',
+        'The same convergence has a second cost. When a page is assembled from the same defaults as everything else, there is less on it that an answer engine could lift and attribute to you rather than to the category.',
+      ],
+    },
+    {
+      heading: 'The score describes the output, never the author',
+      body: [
+        'Band names here are deliberate. They describe what came out, not who made it or how hard they worked, and a low score is not an accusation about the person who shipped it. Plenty of deliberate sites lean on a default or two that the crowd also uses, and the ladder has a band that says exactly that.',
+      ],
+    },
+  ],
+};
+
+const SCORES: ContentPage = {
+  meta: pageLink('/how-the-scores-work'),
+  lead: 'Every reading runs 0-100 and higher is always better. The bands below are the published ladders, read straight out of the same constants the scorers use.',
+  sections: [
+    {
+      heading: 'One scale, three vocabularies',
+      body: [
+        'Three tools reading one site would otherwise produce three numbers a reader has to reconcile. They share the scale so the numbers can be compared, and keep their own band names because what a number means is not the same in each.',
+        'A consolidated verdict is the worst of the readings that ran, not an average. An average hides the one thing that is actually wrong.',
+      ],
+    },
+    {
+      heading: 'Can an answer engine read the page?',
+      table: ladder('The citation ladder', CITATION_BANDS, CITATION_MAX),
+      body: [
+        'Any blocker pins the score into the bottom band on its own. A page that says noindex, or serves no text without JavaScript, or answers a crawler with 403, cannot be quoted whatever else is true of it.',
+      ],
+    },
+    {
+      heading: 'What is the site exposing?',
+      table: ladder('The exposure ladder', EXPOSURE_BANDS, EXPOSURE_MAX),
+    },
+    {
+      heading: 'How much came out of a template?',
+      table: ladder('The slop ladder', TIER_BANDS, SCORE_MAX),
+    },
+    {
+      heading: 'Calibrated against pages that are demonstrably quoted',
+      body: [
+        'The citation weights are set by a corpus of pages answer engines quote every day: Wikipedia, MDN, and the Python, React, nginx and Postgres references, alongside twenty popular pages across news, retail, health, government and SaaS. The rule fixing the numbers is that such a page must come out in the top band, because nothing is in fact standing in its way.',
+        'That rule is what makes the score usable. Before it, the nginx reference scored 68 about a plain served HTML page that is quoted constantly. A scoring system that fails the things everyone cites is measuring its own opinions.',
+      ],
+    },
+    {
+      heading: 'Why an absence costs nothing',
+      body: [
+        'A signal a page simply does not publish is listed and weighs zero. Pricing absences built a score out of choices the most-quoted pages on the web make and are quoted anyway.',
+        'A broken attempt is different and keeps its weight. Somebody meant that canonical to work, and it does not.',
+      ],
+    },
+  ],
+};
+
+/** Every explainer, in the order they are offered. */
+export const CONTENT_PAGES: readonly ContentPage[] = [CITE, KEYS, SLOP, SCORES];

--- a/apps/console/build/pages/render.ts
+++ b/apps/console/build/pages/render.ts
@@ -1,0 +1,118 @@
+import { NAME, PUBLISHER } from '../../src/copy.js';
+import type { PageLink } from '../../src/pages.js';
+import { headTags } from '../head.js';
+import { escapeHtml } from '../html.js';
+import { CONTENT_PAGES, type ContentPage, type Section, type Table } from './content.js';
+
+/**
+ * An explainer as a complete document, with no React in it.
+ *
+ * A real file at a real path rather than a route: the app reaches its readings
+ * through `?site=`, deliberately, so a static host never has to rewrite unknown
+ * paths. These pages keep that property by existing on disk.
+ *
+ * No meter appears on any of them. The consolidated verdict stays on the one
+ * surface, which is the whole reason the app has a single screen.
+ */
+
+const STYLE = [
+  ':root{color-scheme:light dark}',
+  'body{margin:0;background:var(--paper-base,#f5f2e8)}',
+  '.doc{max-width:44rem;margin:0 auto;padding:2.5rem 1.5rem 4rem;color:var(--ink-1,#151b28);font-family:Archivo,system-ui,sans-serif;font-size:1.02rem;line-height:1.62}',
+  '.doc a{color:var(--hand,#2f4fb5)}',
+  '.doc nav.top{display:flex;gap:1rem;font-family:"Architects Daughter",cursive;font-size:1.3rem;margin-bottom:2.5rem}',
+  '.doc h1{font-family:"Architects Daughter",cursive;font-size:2.3rem;line-height:1.12;color:var(--hand,#2f4fb5);margin:0 0 1rem}',
+  '.doc .lead{font-size:1.16rem;line-height:1.5;color:var(--ink-2,#414b63);margin:0 0 2.5rem}',
+  '.doc h2{font-family:"Architects Daughter",cursive;font-size:1.5rem;font-weight:400;line-height:1.2;margin:2.75rem 0 .75rem;color:var(--ink-1,#151b28)}',
+  '.doc p{margin:0 0 1rem}',
+  '.doc ul{margin:0 0 1rem;padding-left:1.2rem}',
+  '.doc li{margin:.4rem 0}',
+  // Tables carry the published ladders and must not push the page sideways on
+  // a phone, so the scroll is the table's own.
+  '.doc .scroll{overflow-x:auto;margin:0 0 1.25rem}',
+  '.doc table{border-collapse:collapse;width:100%;font-size:.95rem}',
+  '.doc caption{text-align:left;font-family:"Architects Daughter",cursive;font-size:1.05rem;color:var(--ink-3,#545f78);padding-bottom:.4rem}',
+  '.doc th,.doc td{text-align:left;padding:.5rem .75rem;border-bottom:1px solid var(--line-base,#dbe2f2);vertical-align:top}',
+  '.doc th{font-weight:600;white-space:nowrap}',
+  '.doc .cta{display:inline-block;margin:2.5rem 0 0;padding:.7rem 1.1rem;background:var(--hand,#2f4fb5);color:#fff;text-decoration:none;border-radius:3px 9px 4px 8px}',
+  '.doc footer{margin-top:3.5rem;padding-top:1.25rem;border-top:1px solid var(--line-base,#dbe2f2);color:var(--ink-3,#545f78);font-size:.87rem}',
+  '.doc footer nav{display:flex;flex-wrap:wrap;gap:.9rem;margin-bottom:.75rem}',
+].join('');
+
+function tableHtml(table: Table): string {
+  const head = table.head.map((cell) => `<th scope="col">${escapeHtml(cell)}</th>`).join('');
+  const rows = table.rows
+    .map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join('')}</tr>`)
+    .join('\n            ');
+
+  return `<div class="scroll">
+          <table>
+            <caption>${escapeHtml(table.caption)}</caption>
+            <thead><tr>${head}</tr></thead>
+            <tbody>
+            ${rows}
+            </tbody>
+          </table>
+        </div>`;
+}
+
+function sectionHtml(section: Section): string {
+  const parts = [`<h2>${escapeHtml(section.heading)}</h2>`];
+  if (section.table !== undefined) parts.push(tableHtml(section.table));
+  for (const paragraph of section.body ?? []) parts.push(`<p>${escapeHtml(paragraph)}</p>`);
+  if (section.list !== undefined) {
+    const items = section.list.map((item) => `<li>${escapeHtml(item)}</li>`).join('\n            ');
+    parts.push(`<ul>\n            ${items}\n          </ul>`);
+  }
+  return parts.join('\n        ');
+}
+
+/** Every other explainer, so each page is reachable from every other one. */
+function siblings(current: PageLink): string {
+  return CONTENT_PAGES.filter((page) => page.meta.path !== current.path)
+    .map((page) => `<a href="${page.meta.path}">${escapeHtml(page.meta.title)}</a>`)
+    .join('\n            ');
+}
+
+export function renderPage(page: ContentPage, origin: string | null, hasImage: boolean): string {
+  const sections = page.sections.map(sectionHtml).join('\n\n        ');
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    ${headTags(page.meta, origin, hasImage)}
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <meta name="color-scheme" content="light dark" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&amp;family=Architects+Daughter&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>${STYLE}</style>
+  </head>
+  <body>
+    <main class="doc">
+      <nav class="top"><a href="/">${escapeHtml(NAME.toLowerCase())}</a></nav>
+
+      <h1>${escapeHtml(page.meta.title)}</h1>
+      <p class="lead">${escapeHtml(page.lead)}</p>
+
+      ${sections}
+
+      <a class="cta" href="/">Read a site with ${escapeHtml(NAME)}</a>
+
+      <footer>
+        <nav>
+          <a href="/">${escapeHtml(NAME)}</a>
+          ${siblings(page.meta)}
+        </nav>
+        ${escapeHtml(NAME)} by ${escapeHtml(PUBLISHER)}
+      </footer>
+    </main>
+  </body>
+</html>
+`;
+}

--- a/apps/console/build/seo.ts
+++ b/apps/console/build/seo.ts
@@ -1,0 +1,132 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import type { Plugin, ResolvedConfig } from 'vite';
+import { HOME, OG_IMAGE, headTags } from './head.js';
+import { CONTENT_PAGES } from './pages/content.js';
+import { renderPage } from './pages/render.js';
+import { staticShell } from './shell.js';
+import { SITE_URL_VAR, siteOrigin } from './site.js';
+import { llmsTxt, robotsTxt, sitemapXml } from './wellKnown.js';
+
+/**
+ * The screenshot the README already uses, rather than a second copy under
+ * `public/`: two pictures of one screen can disagree about what the app is.
+ */
+const CARD_SOURCE = new URL('../../../assets/readout-home.jpg', import.meta.url);
+
+/**
+ * Where the generated markup goes. A miss THROWS rather than no-ops:
+ * `String.replace` with no match returns the string unchanged, so editing an
+ * anchor out of `index.html` would silently ship the empty `#root` that
+ * `access.shell` calls a blocker, and the build would look fine.
+ */
+const HEAD_ANCHOR = '<!--seo:head-->';
+const MOUNT_ANCHOR = '<div id="root"></div>';
+
+/** Served in dev and emitted at build, so what you check locally is what ships. */
+interface WellKnownFile {
+  readonly name: string;
+  readonly type: string;
+  readonly body: string;
+}
+
+function wellKnown(origin: string | null): readonly WellKnownFile[] {
+  const text = 'text/plain; charset=utf-8';
+  return [
+    { name: 'robots.txt', type: text, body: robotsTxt(origin) },
+    { name: 'llms.txt', type: text, body: llmsTxt(origin) },
+    // A sitemap is absolute URLs or it is nothing: `<loc>` has no relative
+    // form, so with no origin there is no honest file to write.
+    ...(origin === null
+      ? []
+      : [
+          { name: 'sitemap.xml', type: 'application/xml; charset=utf-8', body: sitemapXml(origin) },
+        ]),
+  ];
+}
+
+function replaceOnce(html: string, anchor: string, into: string): string {
+  if (!html.includes(anchor)) {
+    throw new Error(`[seo] index.html no longer contains ${anchor}; nothing would be injected.`);
+  }
+  return html.replace(anchor, into);
+}
+
+/**
+ * Everything that makes this app legible to something that is not a browser.
+ *
+ * One plugin rather than three because the parts must agree: the canonical, the
+ * sitemap's entry and the robots.txt `Sitemap:` line are one origin written
+ * three times, and the shell names the readings the JSON-LD lists.
+ */
+export function seo(): Plugin {
+  let origin: string | null = null;
+  let card: Uint8Array | null = null;
+  let files: readonly WellKnownFile[] = [];
+
+  return {
+    name: 'lumioguard:seo',
+    enforce: 'post',
+
+    async configResolved(config: ResolvedConfig) {
+      // `config.env` is what Vite already loaded from the .env files, so this
+      // reads the same value the app would and needs no access to the process.
+      origin = siteOrigin(config.env);
+      files = wellKnown(origin);
+      if (origin === null) {
+        config.logger.warn(
+          `[seo] ${SITE_URL_VAR} is not set: no canonical, no OpenGraph URL, no sitemap and no Sitemap: line in robots.txt. Set it to this deployment's origin before publishing.`,
+        );
+      }
+
+      try {
+        card = await readFile(fileURLToPath(CARD_SOURCE));
+      } catch {
+        // Missing art costs the card, not the build. Half an OpenGraph image
+        // is a broken preview, so the tags are omitted with it.
+        card = null;
+        config.logger.warn('[seo] No card image at assets/readout-home.jpg: og:image omitted.');
+      }
+    },
+
+    transformIndexHtml: {
+      order: 'post',
+      handler(html: string) {
+        const withHead = replaceOnce(html, HEAD_ANCHOR, headTags(HOME, origin, card !== null));
+        return replaceOnce(withHead, MOUNT_ANCHOR, `<div id="root">${staticShell()}\n    </div>`);
+      },
+    },
+
+    /** Dev serves the same bytes the build emits, so a check locally is a check. */
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const path = (req.url ?? '').split('?')[0];
+        const match = files.find((file) => path === `/${file.name}`);
+        if (match === undefined) return next();
+        res.setHeader('content-type', match.type);
+        res.end(match.body);
+      });
+    },
+
+    generateBundle() {
+      for (const file of files) {
+        this.emitFile({ type: 'asset', fileName: file.name, source: file.body });
+      }
+      // `<slug>.html`, NOT `<slug>/index.html`. Cloudflare Pages answers
+      // `/slug` from `/slug.html` with a 200, but answers it from
+      // `/slug/index.html` with a 308 to `/slug/`. That redirect would make
+      // every canonical, sitemap entry and internal link point at a URL that
+      // moves, which is a defect the tool in this repo reports.
+      for (const page of CONTENT_PAGES) {
+        this.emitFile({
+          type: 'asset',
+          fileName: `${page.meta.path.replace(/^\//, '')}.html`,
+          source: renderPage(page, origin, card !== null),
+        });
+      }
+      if (card !== null) {
+        this.emitFile({ type: 'asset', fileName: OG_IMAGE.file, source: card });
+      }
+    },
+  };
+}

--- a/apps/console/build/shell.ts
+++ b/apps/console/build/shell.ts
@@ -1,0 +1,86 @@
+import {
+  DESCRIPTION,
+  EXAMPLES,
+  HEADLINE_TEXT,
+  HOW_IT_WORKS,
+  NAME,
+  PUBLISHER,
+} from '../src/copy.js';
+import { PAGES } from '../src/pages.js';
+import { CATALOGUE } from '../src/tools/catalogue.js';
+import { escapeHtml } from './html.js';
+
+/** Scoped to the shell, and thrown away with it. */
+const STYLE = [
+  '.shell{max-width:64rem;margin:0 auto;padding:3rem 1.5rem;color:var(--ink-1,#151b28);font-family:Archivo,system-ui,sans-serif;line-height:1.55}',
+  '.shell h1{font-family:"Architects Daughter",cursive;font-size:2.25rem;line-height:1.12;color:var(--hand,#2f4fb5);margin:0 0 1rem;max-width:20ch}',
+  '.shell h2{font-family:"Architects Daughter",cursive;font-size:1.25rem;font-weight:400;color:var(--ink-3,#545f78);margin:2rem 0 .5rem}',
+  '.shell p{margin:0 0 1rem;max-width:62ch}',
+  '.shell ul,.shell ol{margin:0;padding-left:1.25rem;max-width:62ch}',
+  // The stylesheet this lands beside resets markers away, and a numbered step
+  // that renders unnumbered has lost the thing making it a step.
+  '.shell ul{list-style:disc}',
+  '.shell ol{list-style:decimal}',
+  '.shell li{margin:.35rem 0}',
+  '.shell nav{display:flex;flex-wrap:wrap;gap:.75rem;margin-top:.5rem}',
+  '.shell a{color:var(--hand,#2f4fb5)}',
+  '.shell footer{margin-top:2.5rem;color:var(--ink-3,#545f78);font-size:.85rem}',
+].join('');
+
+/**
+ * The document a reader gets before any JavaScript runs, and the only one most
+ * crawlers that feed answer engines ever get.
+ *
+ * Served empty, `#root` is `access.shell`, a blocker that pins the page into
+ * the bottom band on its own. Every word is imported, because served text that
+ * differs from what a reader sees is `access.agent-thin`. React clears the
+ * container on first commit, so the style block sits inside it.
+ */
+export function staticShell(): string {
+  const tools = CATALOGUE.map(
+    (tool) => `<li><b>${escapeHtml(tool.label)}.</b> ${escapeHtml(tool.summary)}</li>`,
+  ).join('\n          ');
+
+  const beats = [HOW_IT_WORKS.paste, HOW_IT_WORKS.read, HOW_IT_WORKS.result]
+    .map((beat) => `<li>${escapeHtml(beat)}</li>`)
+    .join('\n          ');
+
+  // The addresses the app itself reads on load, so each works whether or not
+  // the script arrives, and they are the only way out of this page.
+  const examples = EXAMPLES.map(
+    (site) => `<a href="/?site=${encodeURIComponent(site)}">Read ${escapeHtml(site)}</a>`,
+  ).join('\n          ');
+
+  const reading = PAGES.map(
+    (page) => `<li><a href="${page.path}">${escapeHtml(page.title)}</a></li>`,
+  ).join('\n          ');
+
+  return `
+      <div class="shell">
+        <style>${STYLE}</style>
+        <h1>${escapeHtml(HEADLINE_TEXT)}</h1>
+        <p>${escapeHtml(DESCRIPTION)}</p>
+
+        <h2>What to read</h2>
+        <ul>
+          ${tools}
+        </ul>
+
+        <h2>How it works</h2>
+        <ol>
+          ${beats}
+        </ol>
+
+        <h2>Try one</h2>
+        <nav>
+          ${examples}
+        </nav>
+
+        <h2>How it is measured</h2>
+        <ul>
+          ${reading}
+        </ul>
+
+        <footer>${escapeHtml(NAME)} by ${escapeHtml(PUBLISHER)}</footer>
+      </div>`;
+}

--- a/apps/console/build/site.ts
+++ b/apps/console/build/site.ts
@@ -1,0 +1,37 @@
+/**
+ * Where this deployment answers. A canonical, an OpenGraph URL and a sitemap
+ * entry are absolute by definition and cannot be written without it.
+ *
+ * From the environment, never a literal: this repo is public, and a fork would
+ * otherwise ship a canonical pointing at our host. That is
+ * `document.foreign-canonical`, a blocker. Unset writes none of them, because a
+ * wrong canonical hands the page's standing to another address.
+ */
+export const SITE_URL_VAR = 'VITE_PUBLIC_SITE_URL';
+
+/**
+ * The origin, or null when none was configured.
+ *
+ * A malformed value throws rather than falling back to null: quietly omitting
+ * everything ships a deployment that looks built and carries no metadata.
+ */
+export function siteOrigin(env: Readonly<Record<string, unknown>>): string | null {
+  const raw = env[SITE_URL_VAR];
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    throw new Error(`${SITE_URL_VAR} is not a URL: ${raw}`);
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error(`${SITE_URL_VAR} must be http or https, not ${url.protocol}`);
+  }
+  return url.origin;
+}
+
+/** An absolute URL on this site, for a path that always starts with a slash. */
+export function absolute(origin: string, path: string): string {
+  return `${origin}${path}`;
+}

--- a/apps/console/build/wellKnown.ts
+++ b/apps/console/build/wellKnown.ts
@@ -1,0 +1,93 @@
+import { DESCRIPTION, EXAMPLES, NAME } from '../src/copy.js';
+import { CATALOGUE } from '../src/tools/catalogue.js';
+import { CONTENT_PAGES } from './pages/content.js';
+import { absolute } from './site.js';
+
+/**
+ * The files a crawler looks for before it looks at a page. Generated rather
+ * than checked in: two carry absolute URLs and the third has to agree with
+ * them, and a robots.txt naming a sitemap on the wrong host reports nothing.
+ */
+
+/**
+ * `Disallow:` with an empty value is RFC 9309 for "all of it is yours", and no
+ * agent is blocked: a site whose subject is machine legibility turning machines
+ * away is the `access.llms-contradiction` pair with llms.txt below.
+ */
+export function robotsTxt(origin: string | null): string {
+  const lines = [
+    `# ${NAME}. Every page here is meant to be found, by people and by agents.`,
+    '',
+    'User-agent: *',
+    'Disallow:',
+    '',
+  ];
+  // A sitemap line needs an absolute URL; there is no relative form of it.
+  if (origin !== null) lines.push(`Sitemap: ${absolute(origin, '/sitemap.xml')}`, '');
+  return lines.join('\n');
+}
+
+/**
+ * The app, then every explainer. Readings are not listed: they live at
+ * `?site=…` on the app and canonicalise back to it, so each would be the same
+ * document under another name.
+ *
+ * No `lastmod`, which would have to be the build time and so would change when
+ * nothing about the page did. No `changefreq` or `priority`; nothing reads them.
+ */
+export function sitemapXml(origin: string): string {
+  const paths = ['/', ...CONTENT_PAGES.map((page) => page.meta.path)];
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...paths.flatMap((path) => ['  <url>', `    <loc>${absolute(origin, path)}</loc>`, '  </url>']),
+    '</urlset>',
+    '',
+  ].join('\n');
+}
+
+/**
+ * The same page, written for something that is going to read it rather than
+ * render it. Format per llmstxt.org: one H1, a blockquote summary, then
+ * sections of links.
+ *
+ * The readings are listed from the catalogue, so this file cannot describe a
+ * set of tools the app does not offer.
+ */
+export function llmsTxt(origin: string | null): string {
+  const link = (path: string): string => (origin === null ? path : absolute(origin, path));
+
+  const readings = CATALOGUE.map(
+    (tool) => `- [${tool.label}](${link(`/?tools=${tool.id}`)}): ${tool.summary}`,
+  );
+
+  const examples = EXAMPLES.map(
+    (site) => `- [${site}](${link(`/?site=${encodeURIComponent(site)}`)}): a reading of ${site}`,
+  );
+
+  return [
+    `# ${NAME}`,
+    '',
+    `> ${DESCRIPTION}`,
+    '',
+    'Paste any public URL. Every reading you pick runs at once against its own',
+    'engine, and they land on a single verdict: the worst of them, with each',
+    'reading underneath it. Every reading is a read: no tool here writes to the',
+    'site it is reading.',
+    '',
+    '## Readings',
+    '',
+    ...readings,
+    '',
+    '## Examples',
+    '',
+    ...examples,
+    '',
+    '## Reference',
+    '',
+    ...CONTENT_PAGES.map(
+      (page) => `- [${page.meta.title}](${link(page.meta.path)}): ${page.meta.description}`,
+    ),
+    '',
+  ].join('\n');
+}

--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -3,11 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Readout, what does this site give away?</title>
-    <meta
-      name="description"
-      content="Reads a site with every tool you pick and lands them on one verdict: how much of it came out of a template, what it is exposing to anyone with the URL, and whether an answer engine can quote it."
-    />
+    <!-- Written at build time from `src/copy.ts` and the tool catalogue, so
+         what a crawler is told and what a reader is shown come from one
+         source. Removing the anchor below fails the build. See `build/seo.ts`. -->
+    <!--seo:head-->
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/console/public/_headers
+++ b/apps/console/public/_headers
@@ -1,0 +1,35 @@
+# Cloudflare Pages reads this from the build output. `public/` is copied there
+# verbatim, so this file ships as-is.
+
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  # The workers send `no-referrer` because they are handed other people's URLs.
+  # This is a public page and its referrer is only ever its own address, which
+  # is worth sending: it is how a site being read can tell where the visit came
+  # from.
+
+# Hashed at build, so the name changes whenever the bytes do and nothing here
+# ever needs to be revalidated.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# The document is NOT hashed, and it is the file carrying the canonical, the
+# OpenGraph tags and the structured data. Cached for a day it would keep serving
+# yesterday's metadata after a deploy that existed to change it.
+/
+  Cache-Control: public, max-age=0, must-revalidate
+
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+# Read by crawlers rather than browsers, and stale ones are how a sitemap comes
+# to list a page that moved.
+/robots.txt
+  Cache-Control: public, max-age=3600
+
+/sitemap.xml
+  Cache-Control: public, max-age=3600
+
+/llms.txt
+  Cache-Control: public, max-age=3600

--- a/apps/console/public/favicon.svg
+++ b/apps/console/public/favicon.svg
@@ -1,6 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <title>Leakpeek</title>
-  <rect width="32" height="32" rx="7" fill="#c31f29"/>
-  <path d="M16 8.5a5 5 0 0 0-3 9l-1.6 5.2a1 1 0 0 0 1 1.3h7.2a1 1 0 0 0 1-1.3L19 17.5a5 5 0 0 0-3-9Z" fill="#ffffff"/>
-  <circle cx="16" cy="13.4" r="1.9" fill="#c31f29"/>
+  <title>Readout</title>
+  <rect width="32" height="32" rx="7" fill="#bf242d"/>
+  <g transform="translate(2.5 6.1) scale(0.9)" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M2 3.4c8-1 18-1.2 26 .2 1 .1 1.4 1 1.3 2-.3 3.6-.4 8.2-.2 12.6.1 1.3-.4 2-1.6 2.1-8 .9-17 .9-25 .1-1.1-.1-1.7-.7-1.7-1.9C1 14 .9 9 1.2 4.6 1.3 3.8 1.5 3.5 2 3.4Z"/>
+    <path d="M9.6 11.4a2.6 2.6 0 1 1-.1-.2M21.4 11.3a2.6 2.6 0 1 1-.1-.2" stroke-width="1.6"/>
+    <path d="M11.8 11.6c2-.3 4.2-.3 6.3 0" stroke-width="1.6"/>
+  </g>
 </svg>

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -10,36 +10,13 @@ import {
   ThemeToggle,
   useTheme,
 } from '@lumioguard/ui';
+import { EXAMPLES, HEADLINE, HOW_IT_WORKS, NAME, PUBLISHER } from './copy.js';
 import { ConsoleReport } from './features/report/ConsoleReport.js';
 import { useConsoleRoute } from './features/scan/useConsoleRoute.js';
 import { ToolPicker } from './features/select/ToolPicker.js';
+import { PAGES } from './pages.js';
 import { TOOLS } from './tools/index.js';
 import { toolsById } from './tools/registry.js';
-
-/** The app's own name. The parent's is optional and may be absent entirely. */
-const NAME = 'Readout';
-
-/**
- * Sites everyone knows, chosen because their readings disagree with each other.
- *
- * apple.com comes out clean on Citecheck and is the most templated of the three
- * on nothing; nytimes.com answers a crawler with 403 while serving a browser
- * normally. A consolidated verdict is only worth drawing when the parts can
- * differ, and these show that in one click.
- */
-const EXAMPLES = ['apple.com', 'figma.com', 'nytimes.com'];
-
-/**
- * The three beats, in this app's own words.
- *
- * No tool count: the registry decides how many there are, and a number typed
- * here would describe whatever was true the day it was written.
- */
-const HOW_IT_WORKS = {
-  paste: 'Paste a URL',
-  read: 'Every reading you picked runs at once, each against its own engine',
-  result: 'One verdict, the worst of them, with each reading underneath',
-};
 
 function Masthead({ onHome, atHome }: { readonly onHome: () => void; readonly atHome: boolean }) {
   const { theme, toggle } = useTheme();
@@ -96,7 +73,7 @@ function AskView({
         <div className="grid gap-x-[46px] lg:grid-cols-[minmax(0,7fr)_minmax(0,4fr)]">
           <div className="flex flex-col lg:self-center">
             <h1 className="m-0 max-w-[20ch] text-balance font-hand text-36 leading-[1.12] text-hand lg:text-48">
-              What does this site <span className="whitespace-nowrap">give away?</span>
+              {HEADLINE.lead} <span className="whitespace-nowrap">{HEADLINE.tail}</span>
             </h1>
 
             <ScanBar examples={EXAMPLES} onScan={onScan} />
@@ -123,6 +100,22 @@ function Colophon(): JSX.Element {
         <ParentCredit />
       </p>
 
+      {/* Real documents at real paths, not app routes. They are here rather
+          than only in the prerendered shell because a crawler that runs
+          JavaScript sees what React rendered, and a link only the shell carried
+          is one it never follows. */}
+      <nav className="flex flex-wrap gap-x-5 gap-y-1">
+        {PAGES.map((page) => (
+          <a
+            key={page.path}
+            href={page.path}
+            className="text-13 leading-[1.5] text-ink-3 underline-offset-2 transition-colors hover:text-hand"
+          >
+            {page.title}
+          </a>
+        ))}
+      </nav>
+
       {/* Printed, not written, and not lowercased: a legal notice is the one
           string here that is neither the product's voice nor its wordmark.
 
@@ -130,7 +123,7 @@ function Colophon(): JSX.Element {
           goes stale every January is exactly the kind of unattended default
           these tools exist to find on other people's sites. */}
       <p className="m-0 text-13 font-normal leading-[1.5] text-ink-3">
-        © {new Date().getFullYear()} Lumio Software FZ LLC. All rights reserved.
+        © {new Date().getFullYear()} {PUBLISHER}. All rights reserved.
       </p>
     </footer>
   );

--- a/apps/console/src/copy.ts
+++ b/apps/console/src/copy.ts
@@ -1,0 +1,58 @@
+/**
+ * The console's own words.
+ *
+ * Read twice: by the app when it renders, and by the build when it writes the
+ * document a crawler is served. Typed into both they could differ, and served
+ * text that does not match what a reader sees is what Citecheck calls cloaking.
+ */
+
+/** The app's own name. The parent's is optional and may be absent entirely. */
+export const NAME = 'Readout';
+
+/**
+ * The heading, split where it must not wrap: the tail is held on one line so
+ * the question mark never lands by itself. Joined by a space they are the
+ * heading a machine reads, so the split is typesetting and nothing more.
+ */
+export const HEADLINE = { lead: 'What does this site', tail: 'give away?' } as const;
+
+export const HEADLINE_TEXT = `${HEADLINE.lead} ${HEADLINE.tail}`;
+
+/**
+ * The name, then the question the page asks. Derived rather than typed: it was
+ * the heading written out a second time, where retitling one left the other
+ * saying something the page no longer asks.
+ */
+export const TITLE = `${NAME}, ${HEADLINE_TEXT[0]?.toLowerCase() ?? ''}${HEADLINE_TEXT.slice(1)}`;
+
+/**
+ * The one sentence that has to work as the meta description, the OpenGraph
+ * card, the structured data and the static document.
+ *
+ * Held under 160 characters, where a search result stops showing it, which
+ * `build/__tests__/head.test.ts` asserts. Citecheck's own floor of 25 is far
+ * below; the ceiling is the one that bites.
+ */
+export const DESCRIPTION =
+  'Read any public site and land on one verdict: how much came from a template, what it exposes to anyone with the URL, and whether an answer engine can quote it.';
+
+/**
+ * Sites everyone knows, chosen because their readings disagree with each other.
+ * A consolidated verdict is only worth drawing when the parts can differ, and
+ * nytimes.com answering a crawler with 403 while serving a browser normally
+ * shows that in one click.
+ */
+export const EXAMPLES: readonly string[] = ['apple.com', 'figma.com', 'nytimes.com'];
+
+/**
+ * The three beats. No tool count: the registry decides how many there are, and
+ * a number typed here would describe whatever was true the day it was written.
+ */
+export const HOW_IT_WORKS = {
+  paste: 'Paste a URL',
+  read: 'Every reading you picked runs at once, each against its own engine',
+  result: 'One verdict, the worst of them, with each reading underneath',
+} as const;
+
+/** Who the colophon credits, and who the structured data names as publisher. */
+export const PUBLISHER = 'Lumio Software FZ LLC';

--- a/apps/console/src/pages.ts
+++ b/apps/console/src/pages.ts
@@ -1,0 +1,52 @@
+/**
+ * The explainers that sit beside the app, as plain data.
+ *
+ * Here rather than in `build/` because BOTH read it: the build writes each page
+ * and lists it in the sitemap, and the app links to them from the colophon. A
+ * crawler that runs JavaScript sees only what the app renders, so links that
+ * existed solely in the prerendered document would be links Google never
+ * follows.
+ *
+ * `build/pages/content.ts` pairs each entry with its prose, the same way the
+ * tool descriptors pair with the catalogue.
+ */
+export interface PageLink {
+  /** Always starts with a slash, and is the path the document is written to. */
+  readonly path: string;
+  readonly title: string;
+  readonly description: string;
+}
+
+export const PAGES: readonly PageLink[] = [
+  {
+    path: '/can-ai-cite-your-site',
+    title: 'Can an answer engine cite your site?',
+    description:
+      'Most crawlers that feed answer engines do not run JavaScript. What they store for your URL is what your server sent, not what a browser assembles.',
+  },
+  {
+    path: '/api-keys-in-frontend-code',
+    title: 'What your frontend bundle gives away',
+    description:
+      'Everything an app ships to the browser is readable by anyone who opens it. Which keys actually matter, why row-level security is the real control, and what source maps publish.',
+  },
+  {
+    path: '/what-ai-slop-looks-like',
+    title: 'What AI slop actually looks like',
+    description:
+      'Generated sites converge on the same defaults. The specific tells: stock hero lines, bento grids, glow instead of shadow, and the vocabulary chatbots reach for.',
+  },
+  {
+    path: '/how-the-scores-work',
+    title: 'How the scores work',
+    description:
+      'Three readings on one 0-100 scale where higher is better, the published band ladders, and what each one was calibrated against.',
+  },
+];
+
+/** The entry for one path, or a throw: a page with no link is a page nothing reaches. */
+export function pageLink(path: string): PageLink {
+  const found = PAGES.find((page) => page.path === path);
+  if (found === undefined) throw new Error(`No page registered at "${path}"`);
+  return found;
+}

--- a/apps/console/src/tools/__tests__/catalogue.test.ts
+++ b/apps/console/src/tools/__tests__/catalogue.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { CATALOGUE, toolCopy } from '../catalogue.js';
+import { TOOLS } from '../index.js';
+
+/**
+ * The descriptors spread their entry from the catalogue, so a label or a
+ * summary cannot differ. ORDER is the one thing that still could: the registry
+ * decides what a visitor sees first, the catalogue what a crawler reads first.
+ */
+
+describe('CATALOGUE', () => {
+  it('holds every tool the registry offers, in the order it offers them', () => {
+    expect(CATALOGUE.map((tool) => tool.id)).toEqual(TOOLS.map((tool) => tool.id));
+  });
+
+  it('is the source of what each tool is called', () => {
+    for (const tool of TOOLS) {
+      const copy = toolCopy(tool.id);
+      expect(tool.label).toBe(copy.label);
+      expect(tool.summary).toBe(copy.summary);
+    }
+  });
+
+  it('gives every tool a summary that is one sentence, because it is a tooltip', () => {
+    for (const tool of CATALOGUE) {
+      expect(tool.summary.trim().endsWith('.'), `${tool.id} is not a sentence`).toBe(true);
+      expect(tool.summary.split('. ').length, `${tool.id} runs to more than one`).toBe(1);
+    }
+  });
+
+  it('refuses to answer for a tool it does not have', () => {
+    // A descriptor naming nothing would otherwise ship with an undefined label.
+    expect(() => toolCopy('nothing')).toThrow(/nothing/);
+  });
+});

--- a/apps/console/src/tools/catalogue.ts
+++ b/apps/console/src/tools/catalogue.ts
@@ -1,0 +1,45 @@
+/**
+ * What each reading is called and what it does, as plain data.
+ *
+ * Split out of the descriptors so the BUILD can read it: a descriptor is a
+ * `.tsx` pulling in React and the UI package, and the Vite config runs in Node
+ * before any of that exists. The descriptors spread their entry from here, so
+ * the words cannot drift; `catalogue.test.ts` holds the order to the registry.
+ */
+export interface ToolCopy {
+  /** Stable, lower-case, and the segment its dev proxy is mounted at. */
+  readonly id: string;
+  /**
+   * What this reading IS, never what built it. A visitor picking what to read
+   * is choosing between concerns, not between Slopmeter, Leakpeek and Citecheck.
+   */
+  readonly label: string;
+  /** What this tool does, in ONE sentence. It is a tooltip, not a paragraph. */
+  readonly summary: string;
+}
+
+/** Slopmeter first: it is the one a visitor arrives wanting. */
+export const CATALOGUE: readonly ToolCopy[] = [
+  {
+    id: 'slopmeter',
+    label: 'AI slop',
+    summary: 'Scores how much of the site came out of a template rather than a decision.',
+  },
+  {
+    id: 'leakpeek',
+    label: 'Security',
+    summary: 'Reports what the site is exposing to anyone with the URL.',
+  },
+  {
+    id: 'citecheck',
+    label: 'SEO & AI visibility',
+    summary: 'Reports what stops an answer engine reading the site and quoting it.',
+  },
+];
+
+/** The entry for one tool, or a throw: a descriptor naming nothing is a defect. */
+export function toolCopy(id: string): ToolCopy {
+  const found = CATALOGUE.find((tool) => tool.id === id);
+  if (found === undefined) throw new Error(`No catalogue entry for tool "${id}"`);
+  return found;
+}

--- a/apps/console/src/tools/citecheck/index.tsx
+++ b/apps/console/src/tools/citecheck/index.tsx
@@ -1,4 +1,5 @@
 import { apiBase } from '../apiBase.js';
+import { toolCopy } from '../catalogue.js';
 import type { ToolDescriptor } from '../registry.js';
 import { ScanClient } from './ScanClient.js';
 import { AgentSlip } from './report/AgentSlip.js';
@@ -8,9 +9,7 @@ import { tierInk } from './theme.js';
 const client = new ScanClient(apiBase('citecheck'));
 
 export const citecheck: ToolDescriptor = {
-  id: 'citecheck',
-  label: 'SEO & AI visibility',
-  summary: 'Reports what stops an answer engine reading the site and quoting it.',
+  ...toolCopy('citecheck'),
   async run(address, signal) {
     const result = await client.crawl(address, signal);
     return {

--- a/apps/console/src/tools/leakpeek/index.tsx
+++ b/apps/console/src/tools/leakpeek/index.tsx
@@ -1,4 +1,5 @@
 import { apiBase } from '../apiBase.js';
+import { toolCopy } from '../catalogue.js';
 import type { ToolDescriptor } from '../registry.js';
 import { ScanClient } from './ScanClient.js';
 import { FindingList } from './report/FindingList.js';
@@ -7,9 +8,7 @@ import { tierInk } from './theme.js';
 const client = new ScanClient(apiBase('leakpeek'));
 
 export const leakpeek: ToolDescriptor = {
-  id: 'leakpeek',
-  label: 'Security',
-  summary: 'Reports what the site is exposing to anyone with the URL.',
+  ...toolCopy('leakpeek'),
   async run(address, signal) {
     const result = await client.scan(address, signal);
     return {

--- a/apps/console/src/tools/slopmeter/index.tsx
+++ b/apps/console/src/tools/slopmeter/index.tsx
@@ -1,4 +1,5 @@
 import { apiBase } from '../apiBase.js';
+import { toolCopy } from '../catalogue.js';
 import type { ToolDescriptor } from '../registry.js';
 import { ScanClient } from './ScanClient.js';
 import { SiteReport } from './report/SiteReport.js';
@@ -7,9 +8,7 @@ import { tierInk } from './theme.js';
 const client = new ScanClient(apiBase('slopmeter'));
 
 export const slopmeter: ToolDescriptor = {
-  id: 'slopmeter',
-  label: 'AI slop',
-  summary: 'Scores how much of the site came out of a template rather than a decision.',
+  ...toolCopy('slopmeter'),
   async run(address, signal) {
     const result = await client.crawl(address, {}, signal);
     return {

--- a/apps/console/tsconfig.json
+++ b/apps/console/tsconfig.json
@@ -14,5 +14,11 @@
       "@lumioguard/design-tokens/tailwind": ["../../packages/design-tokens/src/tailwind/plugin.ts"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts", "tailwind.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "build/**/*.ts",
+    "vite.config.ts",
+    "tailwind.config.ts"
+  ]
 }

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -5,6 +5,7 @@ import { type ProxyOptions, type UserConfig, defineConfig } from 'vite';
 // read by the Vite config and by scripts/dev-worker.mjs, neither of which is
 // part of the typechecked app.
 import { HOST, apiPorts, appPort } from '../../scripts/ports.mjs';
+import { seo } from './build/seo.js';
 
 const source = (path: string): string => fileURLToPath(new URL(path, import.meta.url));
 
@@ -30,7 +31,7 @@ function toolProxies(): NonNullable<UserConfig['server']>['proxy'] {
 }
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), seo()],
   // Explicit, not inherited: a source map would publish this app's readable
   // source alongside the bundle. No detector reaches the client, but the client
   // is still the half an attacker can read.

--- a/packages/api-core/src/__tests__/headers.test.ts
+++ b/packages/api-core/src/__tests__/headers.test.ts
@@ -1,0 +1,40 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { standardHeaders } from '../http/headers.js';
+
+/**
+ * What every Worker response carries. The failure this guards is silent:
+ * nothing breaks, no response looks wrong, and a header added to two of the
+ * three Workers is one the third quietly does without.
+ */
+
+// `app.request` may answer synchronously, so it is awaited rather than
+// returned: its type is `Response | Promise<Response>` and only one of those
+// has headers to read without unwrapping.
+async function respond(): Promise<Response> {
+  const app = new Hono();
+  app.use('*', standardHeaders());
+  app.get('/api/scan', (context) => context.json({ ok: true }));
+  return await app.request('/api/scan');
+}
+
+describe('standardHeaders', () => {
+  it('keeps every reading out of a search index', async () => {
+    // `/api/scan?url=…` returns JSON about somebody ELSE's site. Indexed, those
+    // are pages about other people's domains published under ours.
+    const headers = (await respond()).headers;
+    expect(headers.get('x-robots-tag')).toBe('noindex, nofollow');
+  });
+
+  it('refuses to let a response be read as a type it did not declare', async () => {
+    expect((await respond()).headers.get('x-content-type-options')).toBe('nosniff');
+  });
+
+  it('sends no referrer, because the URL carries the site somebody asked about', async () => {
+    expect((await respond()).headers.get('referrer-policy')).toBe('no-referrer');
+  });
+
+  it('leaves the body alone', async () => {
+    expect(await (await respond()).json()).toEqual({ ok: true });
+  });
+});

--- a/packages/api-core/src/http/headers.ts
+++ b/packages/api-core/src/http/headers.ts
@@ -1,0 +1,20 @@
+import type { Context, MiddlewareHandler } from 'hono';
+
+/**
+ * What every response from every tool's Worker carries. It was written out in
+ * all three `index.ts` files identically, and a header added to two of the
+ * three is one the third quietly does without.
+ *
+ * `x-robots-tag` is the one that is not merely hygiene: each Worker answers on
+ * its own public origin, and `/api/scan?url=…` returns JSON about somebody
+ * else's site. There is no document to put a meta tag in, so the header is the
+ * only place to say it.
+ */
+export function standardHeaders(): MiddlewareHandler {
+  return async (context: Context, next) => {
+    await next();
+    context.header('x-content-type-options', 'nosniff');
+    context.header('referrer-policy', 'no-referrer');
+    context.header('x-robots-tag', 'noindex, nofollow');
+  };
+}

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -1,4 +1,5 @@
 export { endpoint, jsonBody, queryParams } from './http/endpoint.js';
+export { standardHeaders } from './http/headers.js';
 export type { RequestReader } from './http/endpoint.js';
 export { NOT_FOUND, toHttpFailure } from './http/errors.js';
 export type { HttpFailure } from './http/errors.js';

--- a/tools/citecheck/api/src/index.ts
+++ b/tools/citecheck/api/src/index.ts
@@ -1,4 +1,11 @@
-import { NOT_FOUND, endpoint, jsonBody, queryParams, toHttpFailure } from '@lumioguard/api-core';
+import {
+  NOT_FOUND,
+  endpoint,
+  jsonBody,
+  queryParams,
+  standardHeaders,
+  toHttpFailure,
+} from '@lumioguard/api-core';
 import {
   type CitationRequest,
   type CrawlRequest,
@@ -21,11 +28,7 @@ app.use('*', async (context, next) => {
   return cors({ origin, allowMethods: ['GET', 'POST', 'OPTIONS'] })(context, next);
 });
 
-app.use('*', async (context, next) => {
-  await next();
-  context.header('x-content-type-options', 'nosniff');
-  context.header('referrer-policy', 'no-referrer');
-});
+app.use('*', standardHeaders());
 
 /**
  * Read a page, then record it so the report can hand the reading on. AWAITED

--- a/tools/leakpeek/api/src/index.ts
+++ b/tools/leakpeek/api/src/index.ts
@@ -1,4 +1,4 @@
-import { endpoint, jsonBody, queryParams } from '@lumioguard/api-core';
+import { endpoint, jsonBody, queryParams, standardHeaders } from '@lumioguard/api-core';
 import { NOT_FOUND, toHttpFailure } from '@lumioguard/api-core';
 import { type ExposureRequest, exposureRequestSchema } from '@lumioguard/shared';
 import { type Context, Hono } from 'hono';
@@ -17,11 +17,7 @@ app.use('*', async (context, next) => {
   return cors({ origin, allowMethods: ['GET', 'POST', 'OPTIONS'] })(context, next);
 });
 
-app.use('*', async (context, next) => {
-  await next();
-  context.header('x-content-type-options', 'nosniff');
-  context.header('referrer-policy', 'no-referrer');
-});
+app.use('*', standardHeaders());
 
 /**
  * Read a site, then record it so the report can hand the reading on. AWAITED

--- a/tools/slopmeter/api/src/index.ts
+++ b/tools/slopmeter/api/src/index.ts
@@ -1,4 +1,4 @@
-import { endpoint, jsonBody, queryParams } from '@lumioguard/api-core';
+import { endpoint, jsonBody, queryParams, standardHeaders } from '@lumioguard/api-core';
 import { NOT_FOUND, toHttpFailure } from '@lumioguard/api-core';
 import {
   type AnalyzeRequest,
@@ -26,11 +26,7 @@ app.use('*', async (context, next) => {
   return cors({ origin, allowMethods: ['GET', 'POST', 'OPTIONS'] })(context, next);
 });
 
-app.use('*', async (context, next) => {
-  await next();
-  context.header('x-content-type-options', 'nosniff');
-  context.header('referrer-policy', 'no-referrer');
-});
+app.use('*', standardHeaders());
 
 const scanPage = (input: ScanRequest): Promise<unknown> =>
   getContainer().scanService.scanUrl(input.url);


### PR DESCRIPTION
Readout failed its own Citecheck at the worst rank. The built `index.html` served `<div id="root"></div>` and nothing else, which is a literal match for `access.shell` in `tools/citecheck/core/src/access/rendering.ts`: a **blocker**, and one blocker pins a page into the bottom band whatever else is true of it.

Measured with the engine in this repo, before and after:

| | Rendering | Score | Findings |
|---|---|---|---|
| Before | `shell` | **40, Unreadable** | 1 blocker, 2 minor, 3 absent |
| After | `served` | **100, Legible** | none, at any impact |

All four new pages score 100 / Legible / `served` too.

## What changed

- `#root` is filled at build time from `copy.ts` and the tool catalogue, so served text cannot drift from what a reader sees.
- Canonical, OpenGraph, Twitter cards, a JSON-LD graph naming the publisher, `robots.txt`, `sitemap.xml`, `llms.txt`, cache headers.
- Four prerendered explainer pages, plus one publishing the three band ladders read straight from `CITATION_BANDS`, `EXPOSURE_BANDS` and `TIER_BANDS`.
- `X-Robots-Tag: noindex` on all three Workers; the response headers moved to `api-core`, where they were written out three times.
- The favicon was still Leakpeek's, with `<title>Leakpeek</title>` in it.

## Worth a reviewer's attention

**Pages are emitted flat (`<slug>.html`), not as directory indexes.** Cloudflare Pages answers `/slug` from `/slug.html` with a 200, and from `/slug/index.html` with a **308 to `/slug/`**. Under the second shape every canonical, sitemap entry and internal link points at a URL that moves. `vite preview` hides this by falling back to the app for any unknown path; `wrangler pages dev` does not.

**`build/pages/content.ts` imports `shared` by a relative path on purpose.** It is reached from `vite.config.ts`, which esbuild bundles before any alias exists. A bare specifier is left external, Node loads the package's TypeScript entry, and the build dies. The comment says so.

**One deliberate behaviour change:** injecting into `index.html` now throws if the anchors are gone. `String.replace` with no match returns the string unchanged, so removing an anchor would silently ship the empty mount back with a build that looks fine.

## Before this deploy means anything

`VITE_PUBLIC_SITE_URL` is **not set** as a repository variable. Unset, the build succeeds and ships with no canonical, no OpenGraph URL, no sitemap and no JSON-LD, warning on stderr. That is correct for a fork and wrong for us.

## Gate

`pnpm typecheck && pnpm lint && pnpm test && pnpm build` green. 111 tests, up from 81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiMGHCDBKFgRLAxW1GL3e8