### PR TITLE
feat(console): serve the app under a base path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,6 +259,17 @@ app's `index.html` for any unknown path:
 pnpm --filter @lumioguard/console exec wrangler pages dev dist
 ```
 
+**The app can be mounted under a path.** `VITE_PUBLIC_SITE_URL` may carry one:
+`https://lumioguard.dev/tools` serves the whole thing from `/tools`, and that
+single string is then the only place the mount point is written. Vite's asset
+base, every internal link, the canonical and the sitemap all read it. Passing it
+twice, once as `--base` and once in the URL, is two literals that must agree,
+and a page would link somewhere its own canonical denies.
+
+Mounted, no `robots.txt` is emitted. It is only read at the root of a host, so
+one under `/tools` is a file nothing fetches; the host's own robots.txt governs
+and should name this sitemap with a second `Sitemap:` line.
+
 **Every published number is read from `shared`.** The band tables on
 `/how-the-scores-work` come from `CITATION_BANDS`, `EXPOSURE_BANDS` and
 `TIER_BANDS`, so retuning a ladder moves the published table the same day it

--- a/apps/console/build/__tests__/head.test.ts
+++ b/apps/console/build/__tests__/head.test.ts
@@ -4,6 +4,8 @@ import { CATALOGUE } from '../../src/tools/catalogue.js';
 import { HOME, headTags } from '../head.js';
 
 const ORIGIN = 'https://example.test';
+const ROOT = { base: ORIGIN, path: '' };
+const MOUNTED = { base: `${ORIGIN}/tools`, path: '/tools' };
 
 describe('headTags', () => {
   it('writes nothing absolute without an origin', () => {
@@ -23,11 +25,19 @@ describe('headTags', () => {
   });
 
   it('points the canonical at the home document, not at whatever ?site= is set', () => {
-    expect(headTags(HOME, ORIGIN, true)).toContain(`<link rel="canonical" href="${ORIGIN}/" />`);
+    expect(headTags(HOME, ROOT, true)).toContain(`<link rel="canonical" href="${ORIGIN}/" />`);
+  });
+
+  it('canonicalises to the mount point when the app is served under one', () => {
+    // The whole app can sit at /tools on another host. A canonical written to
+    // the host root would hand every page to a document that is not this one.
+    const tags = headTags(HOME, MOUNTED, true);
+    expect(tags).toContain(`<link rel="canonical" href="${ORIGIN}/tools/" />`);
+    expect(tags).toContain(`<meta property="og:image" content="${ORIGIN}/tools/og.jpg" />`);
   });
 
   it('drops every image tag together when there is no image', () => {
-    const tags = headTags(HOME, ORIGIN, false);
+    const tags = headTags(HOME, ROOT, false);
     expect(tags).not.toContain('og:image');
     expect(tags).not.toContain('twitter:image');
     // Claiming the large card with no picture renders an empty box.
@@ -37,7 +47,7 @@ describe('headTags', () => {
 
 describe('the structured data', () => {
   const block = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/.exec(
-    headTags(HOME, ORIGIN, true),
+    headTags(HOME, ROOT, true),
   );
   const graph = JSON.parse((block?.[1] ?? '{}').replace(/\\u003c/g, '<')) as {
     readonly '@graph': readonly { readonly '@type': string; readonly featureList?: string[] }[];

--- a/apps/console/build/__tests__/pages.test.ts
+++ b/apps/console/build/__tests__/pages.test.ts
@@ -4,6 +4,7 @@ import { CONTENT_PAGES } from '../pages/content.js';
 import { renderPage } from '../pages/render.js';
 
 const ORIGIN = 'https://example.test';
+const ROOT = { base: ORIGIN, path: '' };
 
 /**
  * The explainers exist to be findable, so what is asserted here is the things
@@ -41,7 +42,7 @@ describe('the page register', () => {
 describe('a rendered page', () => {
   for (const page of CONTENT_PAGES) {
     describe(page.meta.path, () => {
-      const html = renderPage(page, ORIGIN, true);
+      const html = renderPage(page, ROOT, true);
 
       it('has exactly one h1, and it is the title', () => {
         // `document.many-h1` and `document.no-h1` both sit on this.
@@ -102,5 +103,27 @@ describe('the published ladders', () => {
   it('names a range that ends at the top of the scale', () => {
     const table = (scores?.sections ?? []).flatMap((s) => (s.table ? [s.table] : []))[0];
     expect(table?.rows[0]?.[1]).toMatch(/-100$/);
+  });
+});
+
+describe('mounted under a path', () => {
+  const MOUNTED = { base: `${ORIGIN}/tools`, path: '/tools' };
+  const page = CONTENT_PAGES[0];
+  if (page === undefined) throw new Error('no content pages');
+  const html = renderPage(page, MOUNTED, true);
+
+  it('canonicalises to the mounted URL, not the host root', () => {
+    expect(html).toContain(`<link rel="canonical" href="${ORIGIN}/tools${page.meta.path}" />`);
+  });
+
+  it('carries the mount point on every in-site link', () => {
+    // A link to `/` from a page mounted at /tools lands on the HOST's home
+    // page, not the app's, which is a dead end the canonical then denies.
+    expect(html).toContain('href="/tools/"');
+    for (const sibling of PAGES) {
+      if (sibling.path === page.meta.path) continue;
+      expect(html, `no mounted link to ${sibling.path}`).toContain(`href="/tools${sibling.path}"`);
+    }
+    expect(html).not.toMatch(/href="\/(?!tools)/);
   });
 });

--- a/apps/console/build/__tests__/shell.test.ts
+++ b/apps/console/build/__tests__/shell.test.ts
@@ -10,7 +10,7 @@ import { staticShell } from '../shell.js';
  */
 
 describe('staticShell', () => {
-  const shell = staticShell();
+  const shell = staticShell('');
 
   it('leaves the mount point holding a document rather than nothing', () => {
     // `<div id="root"></div>`, closed and empty, is what `access.shell` matches,
@@ -69,5 +69,15 @@ describe('staticShell', () => {
   it('escapes markup rather than emitting it', () => {
     expect(shell).toContain('SEO &amp; AI visibility');
     expect(shell).not.toMatch(/&(?![a-z]+;|#\d+;)/i);
+  });
+});
+
+describe('staticShell mounted under a path', () => {
+  const shell = staticShell('/tools');
+
+  it('carries the mount point on every link it writes', () => {
+    expect(shell).toContain('href="/tools/?site=');
+    expect(shell).toContain('href="/tools/can-ai-cite-your-site"');
+    expect(shell).not.toMatch(/href="\/(?!tools)/);
   });
 });

--- a/apps/console/build/__tests__/wellKnown.test.ts
+++ b/apps/console/build/__tests__/wellKnown.test.ts
@@ -4,6 +4,7 @@ import { CATALOGUE } from '../../src/tools/catalogue.js';
 import { llmsTxt, robotsTxt, sitemapXml } from '../wellKnown.js';
 
 const ORIGIN = 'https://example.test';
+const ROOT = { base: ORIGIN, path: '' };
 
 /**
  * Every field a robots.txt may carry, as the major crawlers document them.
@@ -27,7 +28,7 @@ const KNOWN_FIELDS = new Set([
 
 describe('robots.txt', () => {
   it('uses only fields a crawler recognises', () => {
-    for (const raw of robotsTxt(ORIGIN).split('\n')) {
+    for (const raw of robotsTxt(ROOT).split('\n')) {
       const line = raw.replace(/#.*$/, '').trim();
       if (line === '') continue;
       const field = line.slice(0, line.indexOf(':')).toLowerCase();
@@ -39,7 +40,7 @@ describe('robots.txt', () => {
   it('turns nobody away', () => {
     // `Disallow:` with no value is RFC 9309 for "all of it is yours"; blocking
     // machines here would be the `access.llms-contradiction` pair.
-    const text = robotsTxt(ORIGIN);
+    const text = robotsTxt(ROOT);
     expect(text).toContain('User-agent: *');
     expect(text).toMatch(/^Disallow:\s*$/m);
     expect(text).not.toMatch(/^Disallow:\s*\//m);
@@ -48,7 +49,7 @@ describe('robots.txt', () => {
   it('names the sitemap, so a crawler that reads this first still finds it', () => {
     // `access.sitemap-unlisted`: crawlers guessing at /sitemap.xml find it, the
     // ones that read robots.txt first do not look.
-    expect(robotsTxt(ORIGIN)).toContain(`Sitemap: ${ORIGIN}/sitemap.xml`);
+    expect(robotsTxt(ROOT)).toContain(`Sitemap: ${ORIGIN}/sitemap.xml`);
   });
 
   it('omits the sitemap line rather than writing a relative one', () => {
@@ -60,7 +61,7 @@ describe('robots.txt', () => {
 });
 
 describe('sitemap.xml', () => {
-  const xml = sitemapXml(ORIGIN);
+  const xml = sitemapXml(ROOT);
 
   it('lists the app and every explainer, and nothing else', () => {
     // Readings are absent on purpose: they live at `?site=…` on the app and
@@ -85,7 +86,7 @@ describe('sitemap.xml', () => {
 });
 
 describe('llms.txt', () => {
-  const text = llmsTxt(ORIGIN);
+  const text = llmsTxt(ROOT);
 
   it('opens the way the format requires: one H1, then a blockquote summary', () => {
     const lines = text.split('\n').filter((line) => line.trim() !== '');

--- a/apps/console/build/head.ts
+++ b/apps/console/build/head.ts
@@ -2,7 +2,7 @@ import { DESCRIPTION, NAME, PUBLISHER, TITLE } from '../src/copy.js';
 import type { PageLink } from '../src/pages.js';
 import { CATALOGUE } from '../src/tools/catalogue.js';
 import { escapeHtml } from './html.js';
-import { absolute } from './site.js';
+import { type Site, absolute } from './site.js';
 
 /**
  * Where the card image is emitted, and what it is a picture of. The path is
@@ -28,7 +28,7 @@ export const HOME: PageLink = { path: '/', title: TITLE, description: DESCRIPTIO
  * Everything in `<head>` that says what this page is, split by whether it needs
  * the origin. `site.ts` says why the absent case writes nothing.
  */
-export function headTags(page: PageLink, origin: string | null, hasImage: boolean): string {
+export function headTags(page: PageLink, where: Site | null, hasImage: boolean): string {
   const originless: string[] = [
     `<title>${escapeHtml(page.title)}</title>`,
     `<meta name="description" content="${escapeHtml(page.description)}" />`,
@@ -42,9 +42,9 @@ export function headTags(page: PageLink, origin: string | null, hasImage: boolea
     `<meta name="twitter:description" content="${escapeHtml(page.description)}" />`,
   ];
 
-  if (origin === null) return originless.join('\n    ');
+  if (where === null) return originless.join('\n    ');
 
-  const self = absolute(origin, page.path);
+  const self = absolute(where.base, page.path);
   return [
     ...originless,
     // On the app, every reading lives at `?site=…` on this one document, so the
@@ -52,8 +52,8 @@ export function headTags(page: PageLink, origin: string | null, hasImage: boolea
     // site anybody has ever read.
     `<link rel="canonical" href="${escapeHtml(self)}" />`,
     `<meta property="og:url" content="${escapeHtml(self)}" />`,
-    ...(hasImage ? imageTags(absolute(origin, OG_IMAGE.path)) : []),
-    `<script type="application/ld+json">${jsonLd(page, origin, hasImage)}</script>`,
+    ...(hasImage ? imageTags(absolute(where.base, OG_IMAGE.path)) : []),
+    `<script type="application/ld+json">${jsonLd(page, where, hasImage)}</script>`,
   ].join('\n    ');
 }
 
@@ -77,11 +77,11 @@ function imageTags(card: string): string[] {
  * not `Article` on purpose: the Article types carry a date because being dated
  * is part of the type, and an evergreen page has no honest one to give.
  */
-function jsonLd(page: PageLink, origin: string, hasImage: boolean): string {
-  const home = absolute(origin, '/');
-  const self = absolute(origin, page.path);
+function jsonLd(page: PageLink, where: Site, hasImage: boolean): string {
+  const home = absolute(where.base, '/');
+  const self = absolute(where.base, page.path);
 
-  const site = [
+  const nodes = [
     { '@type': 'Organization', '@id': `${home}#publisher`, name: PUBLISHER },
     {
       '@type': 'WebSite',
@@ -96,8 +96,8 @@ function jsonLd(page: PageLink, origin: string, hasImage: boolean): string {
 
   const graph =
     page.path === HOME.path
-      ? [...site, application(home, hasImage ? absolute(origin, OG_IMAGE.path) : null)]
-      : [...site, explainer(page, self, home), breadcrumb(page, self, home)];
+      ? [...nodes, application(home, hasImage ? absolute(where.base, OG_IMAGE.path) : null)]
+      : [...nodes, explainer(page, self, home), breadcrumb(page, self, home)];
 
   // A raw `<` cannot appear inside a script element, whatever it is a script of.
   return JSON.stringify({ '@context': 'https://schema.org', '@graph': graph }).replace(

--- a/apps/console/build/pages/render.ts
+++ b/apps/console/build/pages/render.ts
@@ -2,6 +2,7 @@ import { NAME, PUBLISHER } from '../../src/copy.js';
 import type { PageLink } from '../../src/pages.js';
 import { headTags } from '../head.js';
 import { escapeHtml } from '../html.js';
+import type { Site } from '../site.js';
 import { CONTENT_PAGES, type ContentPage, type Section, type Table } from './content.js';
 
 /**
@@ -68,22 +69,23 @@ function sectionHtml(section: Section): string {
 }
 
 /** Every other explainer, so each page is reachable from every other one. */
-function siblings(current: PageLink): string {
+function siblings(current: PageLink, mount: string): string {
   return CONTENT_PAGES.filter((page) => page.meta.path !== current.path)
-    .map((page) => `<a href="${page.meta.path}">${escapeHtml(page.meta.title)}</a>`)
+    .map((page) => `<a href="${mount}${page.meta.path}">${escapeHtml(page.meta.title)}</a>`)
     .join('\n            ');
 }
 
-export function renderPage(page: ContentPage, origin: string | null, hasImage: boolean): string {
+export function renderPage(page: ContentPage, where: Site | null, hasImage: boolean): string {
   const sections = page.sections.map(sectionHtml).join('\n\n        ');
+  const mount = where?.path ?? '';
 
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    ${headTags(page.meta, origin, hasImage)}
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    ${headTags(page.meta, where, hasImage)}
+    <link rel="icon" href="${mount}/favicon.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <meta name="color-scheme" content="light dark" />
@@ -95,19 +97,19 @@ export function renderPage(page: ContentPage, origin: string | null, hasImage: b
   </head>
   <body>
     <main class="doc">
-      <nav class="top"><a href="/">${escapeHtml(NAME.toLowerCase())}</a></nav>
+      <nav class="top"><a href="${mount}/">${escapeHtml(NAME.toLowerCase())}</a></nav>
 
       <h1>${escapeHtml(page.meta.title)}</h1>
       <p class="lead">${escapeHtml(page.lead)}</p>
 
       ${sections}
 
-      <a class="cta" href="/">Read a site with ${escapeHtml(NAME)}</a>
+      <a class="cta" href="${mount}/">Read a site with ${escapeHtml(NAME)}</a>
 
       <footer>
         <nav>
-          <a href="/">${escapeHtml(NAME)}</a>
-          ${siblings(page.meta)}
+          <a href="${mount}/">${escapeHtml(NAME)}</a>
+          ${siblings(page.meta, mount)}
         </nav>
         ${escapeHtml(NAME)} by ${escapeHtml(PUBLISHER)}
       </footer>

--- a/apps/console/build/seo.ts
+++ b/apps/console/build/seo.ts
@@ -80,7 +80,17 @@ export function seo(): Plugin {
      * must agree: a page would link somewhere its own canonical denies.
      */
     config(userConfig: UserConfig, { mode }): UserConfig {
-      return { base: assetBase(loadEnv(mode, userConfig.root ?? '.', 'VITE_')) };
+      const base = assetBase(loadEnv(mode, userConfig.root ?? '.', 'VITE_'));
+      // An explicit `--base` that disagrees is REFUSED rather than quietly
+      // overruled. Vite would take this hook's value and the flag would do
+      // nothing, so the assets ship under one path while the canonical and
+      // every link claim another, and the build says it succeeded.
+      if (userConfig.base !== undefined && userConfig.base !== base) {
+        throw new Error(
+          `[seo] --base=${userConfig.base} disagrees with ${SITE_URL_VAR} (${base}). The mount point is written once, in the URL; drop the flag.`,
+        );
+      }
+      return { base };
     },
 
     async configResolved(config: ResolvedConfig) {

--- a/apps/console/build/seo.ts
+++ b/apps/console/build/seo.ts
@@ -1,11 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import type { Plugin, ResolvedConfig } from 'vite';
+import { type Plugin, type ResolvedConfig, type UserConfig, loadEnv } from 'vite';
 import { HOME, OG_IMAGE, headTags } from './head.js';
 import { CONTENT_PAGES } from './pages/content.js';
 import { renderPage } from './pages/render.js';
 import { staticShell } from './shell.js';
-import { SITE_URL_VAR, siteOrigin } from './site.js';
+import { SITE_URL_VAR, type Site, assetBase, site } from './site.js';
 import { llmsTxt, robotsTxt, sitemapXml } from './wellKnown.js';
 
 /**
@@ -30,18 +30,21 @@ interface WellKnownFile {
   readonly body: string;
 }
 
-function wellKnown(origin: string | null): readonly WellKnownFile[] {
+function wellKnown(where: Site | null): readonly WellKnownFile[] {
   const text = 'text/plain; charset=utf-8';
+  const mounted = where !== null && where.path !== '';
+
   return [
-    { name: 'robots.txt', type: text, body: robotsTxt(origin) },
-    { name: 'llms.txt', type: text, body: llmsTxt(origin) },
+    // robots.txt is only read at the root of a host. Mounted under a path it is
+    // a file nothing fetches, and shipping one there would claim this app
+    // directs crawlers when the host's own robots.txt is what governs.
+    ...(mounted ? [] : [{ name: 'robots.txt', type: text, body: robotsTxt(where) }]),
+    { name: 'llms.txt', type: text, body: llmsTxt(where) },
     // A sitemap is absolute URLs or it is nothing: `<loc>` has no relative
-    // form, so with no origin there is no honest file to write.
-    ...(origin === null
+    // form, so with no site configured there is no honest file to write.
+    ...(where === null
       ? []
-      : [
-          { name: 'sitemap.xml', type: 'application/xml; charset=utf-8', body: sitemapXml(origin) },
-        ]),
+      : [{ name: 'sitemap.xml', type: 'application/xml; charset=utf-8', body: sitemapXml(where) }]),
   ];
 }
 
@@ -60,7 +63,7 @@ function replaceOnce(html: string, anchor: string, into: string): string {
  * three times, and the shell names the readings the JSON-LD lists.
  */
 export function seo(): Plugin {
-  let origin: string | null = null;
+  let where: Site | null = null;
   let card: Uint8Array | null = null;
   let files: readonly WellKnownFile[] = [];
 
@@ -68,12 +71,24 @@ export function seo(): Plugin {
     name: 'lumioguard:seo',
     enforce: 'post',
 
+    /**
+     * Vite's asset base comes from the SAME variable as the canonical.
+     *
+     * It is decided here, before the config resolves, so `loadEnv` reads the
+     * .env files itself rather than waiting for `config.env`. Writing the mount
+     * point twice, once as `--base` and once in the URL, is two literals that
+     * must agree: a page would link somewhere its own canonical denies.
+     */
+    config(userConfig: UserConfig, { mode }): UserConfig {
+      return { base: assetBase(loadEnv(mode, userConfig.root ?? '.', 'VITE_')) };
+    },
+
     async configResolved(config: ResolvedConfig) {
       // `config.env` is what Vite already loaded from the .env files, so this
       // reads the same value the app would and needs no access to the process.
-      origin = siteOrigin(config.env);
-      files = wellKnown(origin);
-      if (origin === null) {
+      where = site(config.env);
+      files = wellKnown(where);
+      if (where === null) {
         config.logger.warn(
           `[seo] ${SITE_URL_VAR} is not set: no canonical, no OpenGraph URL, no sitemap and no Sitemap: line in robots.txt. Set it to this deployment's origin before publishing.`,
         );
@@ -92,8 +107,12 @@ export function seo(): Plugin {
     transformIndexHtml: {
       order: 'post',
       handler(html: string) {
-        const withHead = replaceOnce(html, HEAD_ANCHOR, headTags(HOME, origin, card !== null));
-        return replaceOnce(withHead, MOUNT_ANCHOR, `<div id="root">${staticShell()}\n    </div>`);
+        const withHead = replaceOnce(html, HEAD_ANCHOR, headTags(HOME, where, card !== null));
+        return replaceOnce(
+          withHead,
+          MOUNT_ANCHOR,
+          `<div id="root">${staticShell(where?.path ?? '')}\n    </div>`,
+        );
       },
     },
 
@@ -121,7 +140,7 @@ export function seo(): Plugin {
         this.emitFile({
           type: 'asset',
           fileName: `${page.meta.path.replace(/^\//, '')}.html`,
-          source: renderPage(page, origin, card !== null),
+          source: renderPage(page, where, card !== null),
         });
       }
       if (card !== null) {

--- a/apps/console/build/shell.ts
+++ b/apps/console/build/shell.ts
@@ -36,7 +36,11 @@ const STYLE = [
  * differs from what a reader sees is `access.agent-thin`. React clears the
  * container on first commit, so the style block sits inside it.
  */
-export function staticShell(): string {
+/**
+ * `mount` is where the app is served from, empty at a host root. Every link
+ * here is written with it, so the same build works at `/` and at `/tools`.
+ */
+export function staticShell(mount: string): string {
   const tools = CATALOGUE.map(
     (tool) => `<li><b>${escapeHtml(tool.label)}.</b> ${escapeHtml(tool.summary)}</li>`,
   ).join('\n          ');
@@ -48,11 +52,11 @@ export function staticShell(): string {
   // The addresses the app itself reads on load, so each works whether or not
   // the script arrives, and they are the only way out of this page.
   const examples = EXAMPLES.map(
-    (site) => `<a href="/?site=${encodeURIComponent(site)}">Read ${escapeHtml(site)}</a>`,
+    (site) => `<a href="${mount}/?site=${encodeURIComponent(site)}">Read ${escapeHtml(site)}</a>`,
   ).join('\n          ');
 
   const reading = PAGES.map(
-    (page) => `<li><a href="${page.path}">${escapeHtml(page.title)}</a></li>`,
+    (page) => `<li><a href="${mount}${page.path}">${escapeHtml(page.title)}</a></li>`,
   ).join('\n          ');
 
   return `

--- a/apps/console/build/site.ts
+++ b/apps/console/build/site.ts
@@ -6,16 +6,46 @@
  * otherwise ship a canonical pointing at our host. That is
  * `document.foreign-canonical`, a blocker. Unset writes none of them, because a
  * wrong canonical hands the page's standing to another address.
+ *
+ * The value MAY carry a path. `https://lumioguard.dev/tools` mounts the whole
+ * app under `/tools`, and that one string is then the only place the mount
+ * point is written: the asset base, every internal link, the canonical and the
+ * sitemap all read it. Split across a `--base` flag and a URL they could
+ * disagree, and a page would link somewhere its own canonical denies.
  */
 export const SITE_URL_VAR = 'VITE_PUBLIC_SITE_URL';
 
+export interface Site {
+  /** Absolute, no trailing slash: `https://lumioguard.dev/tools`. */
+  readonly base: string;
+  /** The mount point for links, no trailing slash. Empty at the root. */
+  readonly path: string;
+}
+
 /**
- * The origin, or null when none was configured.
+ * Where the app is served, or null when nothing was configured.
  *
  * A malformed value throws rather than falling back to null: quietly omitting
  * everything ships a deployment that looks built and carries no metadata.
  */
-export function siteOrigin(env: Readonly<Record<string, unknown>>): string | null {
+export function site(env: Readonly<Record<string, unknown>>): Site | null {
+  const url = configuredUrl(env);
+  if (url === null) return null;
+
+  const path = url.pathname.replace(/\/+$/, '');
+  return { base: `${url.origin}${path}`, path };
+}
+
+/**
+ * What Vite mounts assets under, which needs the trailing slash it omits
+ * everywhere else. `/` when nothing is configured, which is Vite's own default.
+ */
+export function assetBase(env: Readonly<Record<string, unknown>>): string {
+  const where = site(env);
+  return where === null || where.path === '' ? '/' : `${where.path}/`;
+}
+
+function configuredUrl(env: Readonly<Record<string, unknown>>): URL | null {
   const raw = env[SITE_URL_VAR];
   if (typeof raw !== 'string' || raw.trim() === '') return null;
 
@@ -28,10 +58,15 @@ export function siteOrigin(env: Readonly<Record<string, unknown>>): string | nul
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     throw new Error(`${SITE_URL_VAR} must be http or https, not ${url.protocol}`);
   }
-  return url.origin;
+  return url;
 }
 
-/** An absolute URL on this site, for a path that always starts with a slash. */
-export function absolute(origin: string, path: string): string {
-  return `${origin}${path}`;
+/**
+ * An absolute URL on this site, for a path that always starts with a slash.
+ *
+ * Takes the base rather than the origin, so a mounted app's links carry the
+ * mount point without a single call site knowing there is one.
+ */
+export function absolute(base: string, path: string): string {
+  return `${base}${path}`;
 }

--- a/apps/console/build/wellKnown.ts
+++ b/apps/console/build/wellKnown.ts
@@ -1,7 +1,7 @@
 import { DESCRIPTION, EXAMPLES, NAME } from '../src/copy.js';
 import { CATALOGUE } from '../src/tools/catalogue.js';
 import { CONTENT_PAGES } from './pages/content.js';
-import { absolute } from './site.js';
+import { type Site, absolute } from './site.js';
 
 /**
  * The files a crawler looks for before it looks at a page. Generated rather
@@ -14,7 +14,7 @@ import { absolute } from './site.js';
  * agent is blocked: a site whose subject is machine legibility turning machines
  * away is the `access.llms-contradiction` pair with llms.txt below.
  */
-export function robotsTxt(origin: string | null): string {
+export function robotsTxt(where: Site | null): string {
   const lines = [
     `# ${NAME}. Every page here is meant to be found, by people and by agents.`,
     '',
@@ -23,7 +23,7 @@ export function robotsTxt(origin: string | null): string {
     '',
   ];
   // A sitemap line needs an absolute URL; there is no relative form of it.
-  if (origin !== null) lines.push(`Sitemap: ${absolute(origin, '/sitemap.xml')}`, '');
+  if (where !== null) lines.push(`Sitemap: ${absolute(where.base, '/sitemap.xml')}`, '');
   return lines.join('\n');
 }
 
@@ -35,12 +35,16 @@ export function robotsTxt(origin: string | null): string {
  * No `lastmod`, which would have to be the build time and so would change when
  * nothing about the page did. No `changefreq` or `priority`; nothing reads them.
  */
-export function sitemapXml(origin: string): string {
+export function sitemapXml(where: Site): string {
   const paths = ['/', ...CONTENT_PAGES.map((page) => page.meta.path)];
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-    ...paths.flatMap((path) => ['  <url>', `    <loc>${absolute(origin, path)}</loc>`, '  </url>']),
+    ...paths.flatMap((path) => [
+      '  <url>',
+      `    <loc>${absolute(where.base, path)}</loc>`,
+      '  </url>',
+    ]),
     '</urlset>',
     '',
   ].join('\n');
@@ -54,8 +58,8 @@ export function sitemapXml(origin: string): string {
  * The readings are listed from the catalogue, so this file cannot describe a
  * set of tools the app does not offer.
  */
-export function llmsTxt(origin: string | null): string {
-  const link = (path: string): string => (origin === null ? path : absolute(origin, path));
+export function llmsTxt(where: Site | null): string {
+  const link = (path: string): string => (where === null ? path : absolute(where.base, path));
 
   const readings = CATALOGUE.map(
     (tool) => `- [${tool.label}](${link(`/?tools=${tool.id}`)}): ${tool.summary}`,

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -15,6 +15,9 @@ import { ConsoleReport } from './features/report/ConsoleReport.js';
 import { useConsoleRoute } from './features/scan/useConsoleRoute.js';
 import { ToolPicker } from './features/select/ToolPicker.js';
 import { PAGES } from './pages.js';
+
+/** Vite's asset base, without its trailing slash. `''` when served at a root. */
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 import { TOOLS } from './tools/index.js';
 import { toolsById } from './tools/registry.js';
 
@@ -103,12 +106,16 @@ function Colophon(): JSX.Element {
       {/* Real documents at real paths, not app routes. They are here rather
           than only in the prerendered shell because a crawler that runs
           JavaScript sees what React rendered, and a link only the shell carried
-          is one it never follows. */}
+          is one it never follows.
+
+          BASE_URL, not the bare path: the app is served from a host root in
+          development and from `/tools` on lumioguard.dev, and a root-absolute
+          link from there lands on the host's own home page. */}
       <nav className="flex flex-wrap gap-x-5 gap-y-1">
         {PAGES.map((page) => (
           <a
             key={page.path}
-            href={page.path}
+            href={`${BASE}${page.path}`}
             className="text-13 leading-[1.5] text-ink-3 underline-offset-2 transition-colors hover:text-hand"
           >
             {page.title}

--- a/packages/api-core/src/__tests__/cors.test.ts
+++ b/packages/api-core/src/__tests__/cors.test.ts
@@ -1,0 +1,67 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { corsFor } from '../http/cors.js';
+
+/**
+ * The Origin header is chosen by whoever is calling, so every negative case
+ * here is an attempt to be let in by a value that merely looks right.
+ */
+
+async function allow(configured: string | undefined, origin: string): Promise<string | null> {
+  const app = new Hono();
+  app.use('*', corsFor(configured));
+  app.get('/api/health', (context) => context.json({ ok: true }));
+  const response = await app.request('/api/health', { headers: { Origin: origin } });
+  return response.headers.get('access-control-allow-origin');
+}
+
+const LIST = 'https://lumioguard.dev,https://*.lumioguard-website.pages.dev';
+
+describe('corsFor', () => {
+  it('allows everything when unset, which is the development default', async () => {
+    expect(await allow(undefined, 'http://localhost:5200')).toBe('*');
+    expect(await allow('*', 'http://localhost:5200')).toBe('*');
+  });
+
+  it('allows an origin named exactly', async () => {
+    expect(await allow(LIST, 'https://lumioguard.dev')).toBe('https://lumioguard.dev');
+  });
+
+  it('allows any preview subdomain of a wildcard entry', async () => {
+    // Pages gives every branch its own host, so an exact list can only name the
+    // branches that already existed.
+    const preview = 'https://feat-tools-console.lumioguard-website.pages.dev';
+    expect(await allow(LIST, preview)).toBe(preview);
+  });
+
+  it('refuses an origin that is not on the list', async () => {
+    expect(await allow(LIST, 'https://evil.test')).toBeNull();
+  });
+
+  it('refuses another project on the same pages.dev', async () => {
+    // The wildcard is a subdomain of ONE named host. Matching `.pages.dev`
+    // would hand the API to anybody else's Cloudflare project.
+    expect(await allow(LIST, 'https://someone-else.pages.dev')).toBeNull();
+    expect(await allow('https://*.pages.dev', 'https://someone-else.pages.dev')).toBe(
+      'https://someone-else.pages.dev',
+    );
+  });
+
+  it('refuses the bare host of a wildcard entry', async () => {
+    // `*.example.dev` is subdomains, not the apex. Naming the apex is a
+    // separate decision and needs its own entry.
+    expect(
+      await allow('https://*.lumioguard-website.pages.dev', 'https://lumioguard-website.pages.dev'),
+    ).toBeNull();
+  });
+
+  it('refuses a host that merely ends with the allowed text', async () => {
+    // The check parses the origin; a string endsWith would take this.
+    expect(await allow(LIST, 'https://evil-lumioguard-website.pages.dev')).toBeNull();
+  });
+
+  it('refuses a matching host on the wrong scheme or port', async () => {
+    expect(await allow(LIST, 'http://x.lumioguard-website.pages.dev')).toBeNull();
+    expect(await allow(LIST, 'https://x.lumioguard-website.pages.dev:8443')).toBeNull();
+  });
+});

--- a/packages/api-core/src/http/cors.ts
+++ b/packages/api-core/src/http/cors.ts
@@ -1,0 +1,62 @@
+import type { MiddlewareHandler } from 'hono';
+import { cors } from 'hono/cors';
+
+/**
+ * Who may call this Worker from a browser, read from `ALLOWED_ORIGINS`.
+ *
+ * `*` allows everything and is the development default. Otherwise the value is
+ * a comma-separated list of origins, and an entry may carry ONE wildcard label:
+ * `https://*.example.pages.dev` matches any subdomain of `example.pages.dev`.
+ *
+ * The wildcard exists for preview deployments. Cloudflare Pages gives every
+ * branch its own `<branch>.<project>.pages.dev` host, so an exact list can only
+ * ever name the branches that already existed, and testing a change means
+ * watching every reading fail CORS with nothing useful on screen.
+ *
+ * It matches a subdomain of the named host, never the bare host and never a
+ * suffix: `.pages.dev` alone would hand the API to anybody else's project.
+ */
+export function corsFor(configured: string | undefined): MiddlewareHandler {
+  const value = configured ?? '*';
+  if (value === '*') {
+    return cors({ origin: '*', allowMethods: ['GET', 'POST', 'OPTIONS'] });
+  }
+
+  const patterns = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== '');
+
+  return cors({
+    origin: (origin) => (patterns.some((pattern) => matches(pattern, origin)) ? origin : null),
+    allowMethods: ['GET', 'POST', 'OPTIONS'],
+  });
+}
+
+/**
+ * Compared as a parsed URL rather than as text. An `endsWith` on the raw string
+ * would accept `https://evil.test` for a pattern ending in the allowed host as
+ * soon as anything is appended to it, and an Origin header is attacker-chosen.
+ */
+function matches(pattern: string, origin: string): boolean {
+  if (pattern === origin) return true;
+  if (!pattern.includes('*')) return false;
+
+  const wanted = parse(pattern.replace('*.', ''));
+  const actual = parse(origin);
+  if (wanted === null || actual === null) return false;
+
+  return (
+    actual.protocol === wanted.protocol &&
+    actual.port === wanted.port &&
+    actual.hostname.endsWith(`.${wanted.hostname}`)
+  );
+}
+
+function parse(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -1,4 +1,5 @@
 export { endpoint, jsonBody, queryParams } from './http/endpoint.js';
+export { corsFor } from './http/cors.js';
 export { standardHeaders } from './http/headers.js';
 export type { RequestReader } from './http/endpoint.js';
 export { NOT_FOUND, toHttpFailure } from './http/errors.js';

--- a/tools/citecheck/api/src/index.ts
+++ b/tools/citecheck/api/src/index.ts
@@ -1,5 +1,6 @@
 import {
   NOT_FOUND,
+  corsFor,
   endpoint,
   jsonBody,
   queryParams,
@@ -13,7 +14,6 @@ import {
   crawlRequestSchema,
 } from '@lumioguard/shared';
 import { type Context, Hono } from 'hono';
-import { cors } from 'hono/cors';
 import { getContainer } from './container.js';
 import type { Bindings } from './http/env.js';
 import { readingFrom, readingFromCrawl, recorderConfigFrom } from './services/ReadingRecorder.js';
@@ -22,11 +22,7 @@ export type { Env } from './http/env.js';
 
 const app = new Hono<Bindings>();
 
-app.use('*', async (context, next) => {
-  const configured = context.env.ALLOWED_ORIGINS ?? '*';
-  const origin = configured === '*' ? '*' : configured.split(',').map((value) => value.trim());
-  return cors({ origin, allowMethods: ['GET', 'POST', 'OPTIONS'] })(context, next);
-});
+app.use('*', async (context, next) => corsFor(context.env.ALLOWED_ORIGINS)(context, next));
 
 app.use('*', standardHeaders());
 

--- a/tools/citecheck/api/wrangler.toml
+++ b/tools/citecheck/api/wrangler.toml
@@ -18,7 +18,7 @@ name = "lumioguard-citecheck-api"
 # Each tool used to serve its own page and allow only that; the console replaced
 # all three, so a stale per-tool origin here fails every reading with a CORS
 # error and nothing useful on screen. Comma-separated to add a custom domain.
-ALLOWED_ORIGINS = "https://lumioguard-readout.pages.dev"
+ALLOWED_ORIGINS = "https://lumioguard.dev,https://lumioguard-readout.pages.dev"
 # Only this deployment records. Absent from [vars] so a fork's plain
 # `wrangler deploy` posts nowhere; recording also needs CITECHECK_INGEST_SECRET.
 LUMIOGUARD_API_BASE_URL = "https://api.lumioguard.dev"

--- a/tools/citecheck/api/wrangler.toml
+++ b/tools/citecheck/api/wrangler.toml
@@ -18,7 +18,7 @@ name = "lumioguard-citecheck-api"
 # Each tool used to serve its own page and allow only that; the console replaced
 # all three, so a stale per-tool origin here fails every reading with a CORS
 # error and nothing useful on screen. Comma-separated to add a custom domain.
-ALLOWED_ORIGINS = "https://lumioguard.dev,https://lumioguard-readout.pages.dev"
+ALLOWED_ORIGINS = "https://lumioguard.dev,https://*.lumioguard-website.pages.dev,https://lumioguard-readout.pages.dev"
 # Only this deployment records. Absent from [vars] so a fork's plain
 # `wrangler deploy` posts nowhere; recording also needs CITECHECK_INGEST_SECRET.
 LUMIOGUARD_API_BASE_URL = "https://api.lumioguard.dev"

--- a/tools/leakpeek/api/src/index.ts
+++ b/tools/leakpeek/api/src/index.ts
@@ -1,8 +1,7 @@
-import { endpoint, jsonBody, queryParams, standardHeaders } from '@lumioguard/api-core';
+import { corsFor, endpoint, jsonBody, queryParams, standardHeaders } from '@lumioguard/api-core';
 import { NOT_FOUND, toHttpFailure } from '@lumioguard/api-core';
 import { type ExposureRequest, exposureRequestSchema } from '@lumioguard/shared';
 import { type Context, Hono } from 'hono';
-import { cors } from 'hono/cors';
 import { getContainer } from './container.js';
 import type { Bindings } from './http/env.js';
 import { readingFrom, recorderConfigFrom } from './services/ReadingRecorder.js';
@@ -11,11 +10,7 @@ export type { Env } from './http/env.js';
 
 const app = new Hono<Bindings>();
 
-app.use('*', async (context, next) => {
-  const configured = context.env.ALLOWED_ORIGINS ?? '*';
-  const origin = configured === '*' ? '*' : configured.split(',').map((value) => value.trim());
-  return cors({ origin, allowMethods: ['GET', 'POST', 'OPTIONS'] })(context, next);
-});
+app.use('*', async (context, next) => corsFor(context.env.ALLOWED_ORIGINS)(context, next));
 
 app.use('*', standardHeaders());
 

--- a/tools/leakpeek/api/wrangler.toml
+++ b/tools/leakpeek/api/wrangler.toml
@@ -18,7 +18,7 @@ name = "lumioguard-leakpeek-api"
 # Each tool used to serve its own page and allow only that; the console replaced
 # all three, so a stale per-tool origin here fails every reading with a CORS
 # error and nothing useful on screen. Comma-separated to add a custom domain.
-ALLOWED_ORIGINS = "https://lumioguard.dev,https://lumioguard-readout.pages.dev"
+ALLOWED_ORIGINS = "https://lumioguard.dev,https://*.lumioguard-website.pages.dev,https://lumioguard-readout.pages.dev"
 # Only this deployment records. Absent from [vars] so a fork's plain
 # `wrangler deploy` posts nowhere; recording also needs LEAKPEEK_INGEST_SECRET.
 LUMIOGUARD_API_BASE_URL = "https://api.lumioguard.dev"

--- a/tools/leakpeek/api/wrangler.toml
+++ b/tools/leakpeek/api/wrangler.toml
@@ -18,7 +18,7 @@ name = "lumioguard-leakpeek-api"
 # Each tool used to serve its own page and allow only that; the console replaced
 # all three, so a stale per-tool origin here fails every reading with a CORS
 # error and nothing useful on screen. Comma-separated to add a custom domain.
-ALLOWED_ORIGINS = "https://lumioguard-readout.pages.dev"
+ALLOWED_ORIGINS = "https://lumioguard.dev,https://lumioguard-readout.pages.dev"
 # Only this deployment records. Absent from [vars] so a fork's plain
 # `wrangler deploy` posts nowhere; recording also needs LEAKPEEK_INGEST_SECRET.
 LUMIOGUARD_API_BASE_URL = "https://api.lumioguard.dev"

--- a/tools/slopmeter/api/src/index.ts
+++ b/tools/slopmeter/api/src/index.ts
@@ -1,4 +1,4 @@
-import { endpoint, jsonBody, queryParams, standardHeaders } from '@lumioguard/api-core';
+import { corsFor, endpoint, jsonBody, queryParams, standardHeaders } from '@lumioguard/api-core';
 import { NOT_FOUND, toHttpFailure } from '@lumioguard/api-core';
 import {
   type AnalyzeRequest,
@@ -10,7 +10,6 @@ import {
   scanRequestSchema,
 } from '@lumioguard/shared';
 import { type Context, Hono } from 'hono';
-import { cors } from 'hono/cors';
 import { getContainer } from './container.js';
 import type { Bindings } from './http/env.js';
 import { readingFrom } from './mappers/ReadingMapper.js';
@@ -20,11 +19,7 @@ export type { Env } from './http/env.js';
 
 const app = new Hono<Bindings>();
 
-app.use('*', async (context, next) => {
-  const configured = context.env.ALLOWED_ORIGINS ?? '*';
-  const origin = configured === '*' ? '*' : configured.split(',').map((value) => value.trim());
-  return cors({ origin, allowMethods: ['GET', 'POST', 'OPTIONS'] })(context, next);
-});
+app.use('*', async (context, next) => corsFor(context.env.ALLOWED_ORIGINS)(context, next));
 
 app.use('*', standardHeaders());
 

--- a/tools/slopmeter/api/wrangler.toml
+++ b/tools/slopmeter/api/wrangler.toml
@@ -28,5 +28,5 @@ name = "lumioguard-slopmeter-api"
 # The client is served from Pages, a different origin to this Worker, so CORS is
 # load-bearing. Comma-separated: add the origin, not a wildcard, if it ever gets
 # a domain of its own.
-ALLOWED_ORIGINS = "https://lumioguard-readout.pages.dev"
+ALLOWED_ORIGINS = "https://lumioguard.dev,https://lumioguard-readout.pages.dev"
 LUMIOGUARD_API_BASE_URL = "https://api.lumioguard.dev"

--- a/tools/slopmeter/api/wrangler.toml
+++ b/tools/slopmeter/api/wrangler.toml
@@ -28,5 +28,5 @@ name = "lumioguard-slopmeter-api"
 # The client is served from Pages, a different origin to this Worker, so CORS is
 # load-bearing. Comma-separated: add the origin, not a wildcard, if it ever gets
 # a domain of its own.
-ALLOWED_ORIGINS = "https://lumioguard.dev,https://lumioguard-readout.pages.dev"
+ALLOWED_ORIGINS = "https://lumioguard.dev,https://*.lumioguard-website.pages.dev,https://lumioguard-readout.pages.dev"
 LUMIOGUARD_API_BASE_URL = "https://api.lumioguard.dev"


### PR DESCRIPTION
Lets the console be served under a path, so it can sit at `lumioguard.dev/tools`. Pairs with lumiostack/stackguard-web#2.

- `VITE_PUBLIC_SITE_URL` may carry a path; it is the only place the mount point is written
- CORS allows `lumioguard.dev` and `*.lumioguard-website.pages.dev`, so branch previews work
- `--base` that disagrees with the URL now fails instead of being ignored

All five pages score 100/Legible mounted at `/tools`. Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiMGHCDBKFgRLAxW1GL3e8