### PR TITLE
feat(console): set the headline in Archivo via a font-headline token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,9 @@ per-corner radii cycled across four "hands", so no two neighbouring boxes close
 the same way. A single uniform rounded rectangle everywhere reads as a component
 library, which is the exact thing Slopmeter exists to detect.
 
+**The h1 is the one exception, set in Archivo.** It is the first thing read and
+the hand was hard to read at 48px. Everything else keeps the hand.
+
 **The drawn frame is a settled decision.** Both alternatives were built, looked
 at, and reverted on 2026-08-17: one even radius on every frame, and true right
 angles. Treat a proposal to regularise it as already answered.

--- a/apps/console/build/shell.ts
+++ b/apps/console/build/shell.ts
@@ -13,7 +13,7 @@ import { escapeHtml } from './html.js';
 /** Scoped to the shell, and thrown away with it. */
 const STYLE = [
   '.shell{max-width:64rem;margin:0 auto;padding:3rem 1.5rem;color:var(--ink-1,#151b28);font-family:Archivo,system-ui,sans-serif;line-height:1.55}',
-  '.shell h1{font-family:"Architects Daughter",cursive;font-size:2.25rem;line-height:1.12;color:var(--hand,#2f4fb5);margin:0 0 1rem;max-width:20ch}',
+  '.shell h1{font-family:Archivo,system-ui,sans-serif;font-size:2.25rem;line-height:1.12;color:var(--hand,#2f4fb5);margin:0 0 1rem;max-width:20ch}',
   '.shell h2{font-family:"Architects Daughter",cursive;font-size:1.25rem;font-weight:400;color:var(--ink-3,#545f78);margin:2rem 0 .5rem}',
   '.shell p{margin:0 0 1rem;max-width:62ch}',
   '.shell ul,.shell ol{margin:0;padding-left:1.25rem;max-width:62ch}',

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -75,7 +75,7 @@ function AskView({
       <Panel hand="a" span={12}>
         <div className="grid gap-x-[46px] lg:grid-cols-[minmax(0,7fr)_minmax(0,4fr)]">
           <div className="flex flex-col lg:self-center">
-            <h1 className="m-0 max-w-[20ch] text-balance font-hand text-36 leading-[1.12] text-hand lg:text-48">
+            <h1 className="m-0 max-w-[20ch] text-balance font-headline text-36 leading-[1.12] text-hand lg:text-48">
               {HEADLINE.lead} <span className="whitespace-nowrap">{HEADLINE.tail}</span>
             </h1>
 

--- a/packages/design-tokens/src/tailwind/plugin.ts
+++ b/packages/design-tokens/src/tailwind/plugin.ts
@@ -92,6 +92,7 @@ export const designTokensPlugin = plugin(
         fontFamily: {
           hand: [...fontFamily.hand],
           display: [...fontFamily.display],
+          headline: [...fontFamily.headline],
           sans: [...fontFamily.sans],
           mono: [...fontFamily.mono],
         },

--- a/packages/design-tokens/src/tokens/typography.ts
+++ b/packages/design-tokens/src/tokens/typography.ts
@@ -1,10 +1,12 @@
 /**
  * Two faces, two registers, and which one a string gets is a decision about
- * what made it: not about emphasis.
+ * what made it: not about emphasis. `headline` is the h1 alone, which is
+ * printed rather than written because the hand is hard to read at 48px.
  */
 export const fontFamily = {
   hand: ['Architects Daughter', 'ui-rounded', 'cursive'],
   display: ['Architects Daughter', 'ui-rounded', 'cursive'],
+  headline: ['Archivo', 'system-ui', '-apple-system', 'Segoe UI', 'sans-serif'],
   sans: ['Archivo', 'system-ui', '-apple-system', 'Segoe UI', 'sans-serif'],
   mono: ['Archivo', 'system-ui', '-apple-system', 'Segoe UI', 'sans-serif'],
 } as const;


### PR DESCRIPTION
The h1 was set in the hand face and hard to read at 48px. It is now Archivo at regular weight, in the same blue ink.

A named `font-headline` token rather than an inline utility swap, so the one string that is printed rather than written has its own hook. Everything else keeps the hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiMGHCDBKFgRLAxW1GL3e8