### PR TITLE
feat(console): drop the explainer links from the footer

### DIFF
--- a/apps/console/build/__tests__/shell.test.ts
+++ b/apps/console/build/__tests__/shell.test.ts
@@ -77,7 +77,6 @@ describe('staticShell mounted under a path', () => {
 
   it('carries the mount point on every link it writes', () => {
     expect(shell).toContain('href="/tools/?site=');
-    expect(shell).toContain('href="/tools/can-ai-cite-your-site"');
     expect(shell).not.toMatch(/href="\/(?!tools)/);
   });
 });

--- a/apps/console/build/shell.ts
+++ b/apps/console/build/shell.ts
@@ -6,7 +6,6 @@ import {
   NAME,
   PUBLISHER,
 } from '../src/copy.js';
-import { PAGES } from '../src/pages.js';
 import { CATALOGUE } from '../src/tools/catalogue.js';
 import { escapeHtml } from './html.js';
 
@@ -51,10 +50,6 @@ export function staticShell(mount: string): string {
     (site) => `<a href="${mount}/?site=${encodeURIComponent(site)}">Read ${escapeHtml(site)}</a>`,
   ).join('\n          ');
 
-  const reading = PAGES.map(
-    (page) => `<li><a href="${mount}${page.path}">${escapeHtml(page.title)}</a></li>`,
-  ).join('\n          ');
-
   return `
       <div class="shell">
         <style>${STYLE}</style>
@@ -75,11 +70,6 @@ export function staticShell(mount: string): string {
         <nav>
           ${examples}
         </nav>
-
-        <h2>How it is measured</h2>
-        <ul>
-          ${reading}
-        </ul>
 
         <footer>${escapeHtml(NAME)} by ${escapeHtml(PUBLISHER)}</footer>
       </div>`;

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -14,10 +14,6 @@ import { EXAMPLES, HEADLINE, HOW_IT_WORKS, NAME, PUBLISHER } from './copy.js';
 import { ConsoleReport } from './features/report/ConsoleReport.js';
 import { useConsoleRoute } from './features/scan/useConsoleRoute.js';
 import { ToolPicker } from './features/select/ToolPicker.js';
-import { PAGES } from './pages.js';
-
-/** Vite's asset base, without its trailing slash. `''` when served at a root. */
-const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 import { TOOLS } from './tools/index.js';
 import { toolsById } from './tools/registry.js';
 
@@ -102,26 +98,6 @@ function Colophon(): JSX.Element {
         <span className="block text-24 leading-[1.15] text-ink-1">{NAME}</span>
         <ParentCredit />
       </p>
-
-      {/* Real documents at real paths, not app routes. They are here rather
-          than only in the prerendered shell because a crawler that runs
-          JavaScript sees what React rendered, and a link only the shell carried
-          is one it never follows.
-
-          BASE_URL, not the bare path: the app is served from a host root in
-          development and from `/tools` on lumioguard.dev, and a root-absolute
-          link from there lands on the host's own home page. */}
-      <nav className="flex flex-wrap gap-x-5 gap-y-1">
-        {PAGES.map((page) => (
-          <a
-            key={page.path}
-            href={`${BASE}${page.path}`}
-            className="text-13 leading-[1.5] text-ink-3 underline-offset-2 transition-colors hover:text-hand"
-          >
-            {page.title}
-          </a>
-        ))}
-      </nav>
 
       {/* Printed, not written, and not lowercased: a legal notice is the one
           string here that is neither the product's voice nor its wordmark.


### PR DESCRIPTION
The four explainer links are gone from the colophon and from the prerendered shell. The pages themselves stay, keep their canonicals, and stay in `sitemap.xml` and `llms.txt`, so they remain discoverable and indexable.

Removed from **both** renderers deliberately. Keeping them in the crawler document while hiding them from the app is cloaking, which CLAUDE.md forbids and Citecheck reports.

Cost: internal links are a ranking signal, and those four pages now have none pointing at them. Discovery falls to the sitemap alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiMGHCDBKFgRLAxW1GL3e8