### PR TITLE
fix: harden public scanners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,8 @@ body:
       options:
         - leakpeek
         - slopmeter
-        - both
+        - citecheck
+        - multiple tools
         - the shared packages
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/detection_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/detection_proposal.yml
@@ -17,6 +17,7 @@ body:
       options:
         - slopmeter (a tell that a page is still the template)
         - leakpeek (something a site is exposing)
+        - citecheck (something that prevents a site being cited)
     validations:
       required: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,11 @@ jobs:
     name: verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: v${{ inputs.version }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -65,11 +65,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: v${{ inputs.version }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -88,11 +88,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: v${{ inputs.version }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0 # need tags + history to push the bump
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+LumioGuard Tools should be a place where people can disagree precisely and work
+together safely. Be respectful, assume good faith, criticise ideas rather than
+people, and do not harass, threaten, discriminate against, or expose private
+information about another contributor.
+
+Project maintainers may edit or remove contributions and restrict participation
+when conduct threatens that environment. Report conduct concerns privately to
+hello@lumioguard.dev. Reports will be handled confidentially to the extent
+possible, with the safety of affected people taking priority.
+
+This policy applies in project spaces and when someone is representing the
+project elsewhere.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,6 +327,10 @@ deploy. The `.development` infix keeps them out of a production build.
 Secrets never enter git. In production they are Worker secrets
 (`wrangler secret put NAME`), never values in `wrangler.toml`.
 
+Each Worker also declares a `SCAN_RATE_LIMITER` binding in `wrangler.toml`.
+Keep it enabled on public deployments: CORS controls which browsers can read a
+response, but it is not an authentication or abuse-control boundary.
+
 ## A few house rules
 
 - **No casts to escape a type.** `as unknown as X` is always a defect, and so is

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ That starts every tool:
 Nothing else is required. No API keys, no accounts, no services to sign up for.
 A fresh clone scans, scores and renders a full report out of the box.
 
+The workspace packages are intentionally marked `private`: releases publish
+source and deployable Workers, not npm packages. Consume them from a clone or a
+Git dependency rather than expecting them on the npm registry.
+
 ## What is in here
 
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,8 +19,8 @@ the ones that turn a reader into something else:
 - Anything that makes Leakpeek **write** to a target rather than read it
 - Anything that gets a target's data into a report, past the redaction
 - Server-side request forgery: persuading any tool to fetch something it should
-  not reach, such as a cloud metadata endpoint or a private address. A crawl
-  follows links off a third-party page, so every discovered URL is re-validated
+  not reach, such as a cloud metadata endpoint or a private address. Every
+  entry URL, redirect hop, page asset, sitemap and probe URL is re-validated
 - Forging an ingest signature, or replaying a captured reading
 - Recovering Slopmeter's rule pack, or Citecheck's, from what crosses the wire
 
@@ -49,6 +49,12 @@ So you can judge the above for yourself:
 | **Identification** | Every request sends a User-Agent naming the tool, so a site owner can see what it was. **One exception, below** |
 | **Credentials** | Only what the site already published to every visitor, such as a Supabase anon key found in the bundle |
 | **Retention** | Nothing is stored unless you configure the optional LumioGuard integration, which is off by default |
+
+Hosted Workers apply a per-client scan limit through Cloudflare's Rate Limiting
+binding. The repository config sets six expensive API calls per minute for each
+tool. Forks may tune that limit in the tool's `wrangler.toml`; do not remove it
+from an internet-facing deployment. Scan and crawl routes accept POST only so a
+cross-origin image or link cannot start work accidentally.
 
 ### The one request that does not name the tool
 

--- a/packages/api-core/src/__tests__/SafeFetcher.test.ts
+++ b/packages/api-core/src/__tests__/SafeFetcher.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SafeFetcher, readText } from '../services/SafeFetcher.js';
+import { InvalidTargetError } from '../services/TargetResolver.js';
+
+describe('SafeFetcher', () => {
+  it('validates every redirect before following it', async () => {
+    const send = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(null, { status: 302, headers: { location: 'http://169.254.169.254/latest' } }),
+      );
+    await expect(
+      new SafeFetcher(undefined, send).fetch('https://example.com'),
+    ).rejects.toBeInstanceOf(InvalidTargetError);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows safe redirects manually and records their delivery', async () => {
+    const send = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 301, headers: { location: '/final' } }))
+      .mockResolvedValueOnce(new Response('ok'));
+    const result = await new SafeFetcher(undefined, send).fetch('https://example.com/start');
+    expect(result.url.toString()).toBe('https://example.com/final');
+    expect(result.redirects).toBe(1);
+    expect(send.mock.calls[0]?.[1]).toMatchObject({ redirect: 'manual' });
+  });
+
+  it('does not forward credentials across origins', async () => {
+    const send = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, { status: 302, headers: { location: 'https://other.example/final' } }),
+      )
+      .mockResolvedValueOnce(new Response('ok'));
+    await new SafeFetcher(undefined, send).fetch('https://example.com/start', {
+      headers: { authorization: 'Bearer secret', apikey: 'published-key' },
+    });
+    const redirectedHeaders = new Headers(send.mock.calls[1]?.[1]?.headers);
+    expect(redirectedHeaders.has('authorization')).toBe(false);
+    expect(redirectedHeaders.has('apikey')).toBe(false);
+  });
+});
+
+describe('readText', () => {
+  it('stops at the byte ceiling', async () => {
+    const result = await readText(new Response('abcdefghij'), 5);
+    expect(result).toEqual({ text: 'abcde', truncated: true });
+  });
+
+  it('does not mark a shorter response as truncated', async () => {
+    expect(await readText(new Response('abc'), 5)).toEqual({ text: 'abc', truncated: false });
+  });
+
+  it('does not mark a response exactly at the ceiling as truncated', async () => {
+    expect(await readText(new Response('abcde'), 5)).toEqual({ text: 'abcde', truncated: false });
+  });
+});

--- a/packages/api-core/src/__tests__/TargetResolver.test.ts
+++ b/packages/api-core/src/__tests__/TargetResolver.test.ts
@@ -32,8 +32,22 @@ describe('TargetResolver: what it refuses', () => {
     ['172.31.255.254', 'RFC1918 /12 upper bound'],
     ['169.254.169.254', 'link-local, the AWS metadata address'],
     ['127.1.2.3', 'the rest of loopback, not just 127.0.0.1'],
+    ['100.64.0.1', 'carrier-grade NAT'],
+    ['192.0.2.1', 'documentation range'],
+    ['198.51.100.1', 'documentation range'],
+    ['203.0.113.1', 'documentation range'],
+    ['224.0.0.1', 'multicast'],
   ])('refuses the private address %s (%s)', (host) => {
     expect(() => resolver.resolve(`https://${host}/`)).toThrow(InvalidTargetError);
+  });
+
+  it.each(['[fc00::1]', '[fe80::1]', '[ff02::1]', '[::ffff:127.0.0.1]', '[2001:db8::1]'])(
+    'refuses the non-public IPv6 address %s',
+    (host) => expect(() => resolver.resolve(`https://${host}/`)).toThrow(InvalidTargetError),
+  );
+
+  it('refuses a blocked hostname with a trailing root dot', () => {
+    expect(() => resolver.resolve('https://localhost./')).toThrow(InvalidTargetError);
   });
 
   // 172.15 and 172.32 sit OUTSIDE the private /12; refusing them would be a
@@ -66,6 +80,10 @@ describe('TargetResolver: what it refuses', () => {
 
   it('refuses something that is not a URL at all', () => {
     expect(() => resolver.resolve('http://')).toThrow(InvalidTargetError);
+  });
+
+  it('refuses credentials embedded in a URL', () => {
+    expect(() => resolver.resolve('https://user:secret@example.com')).toThrow(InvalidTargetError);
   });
 
   // Case is not a way past the list.

--- a/packages/api-core/src/__tests__/rateLimit.test.ts
+++ b/packages/api-core/src/__tests__/rateLimit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+import { allowedByRateLimit } from '../http/rateLimit.js';
+
+describe('allowedByRateLimit', () => {
+  it('fails open when a local fork has no binding', async () => {
+    await expect(allowedByRateLimit(undefined, new Request('https://example.com'))).resolves.toBe(
+      true,
+    );
+  });
+
+  it('keys the platform limiter by the connecting client', async () => {
+    const limit = vi.fn(async () => ({ success: false }));
+    const request = new Request('https://example.com', {
+      headers: { 'cf-connecting-ip': '203.0.113.8' },
+    });
+    await expect(allowedByRateLimit({ limit }, request)).resolves.toBe(false);
+    expect(limit).toHaveBeenCalledWith({ key: '203.0.113.8' });
+  });
+});

--- a/packages/api-core/src/http/endpoint.ts
+++ b/packages/api-core/src/http/endpoint.ts
@@ -22,18 +22,6 @@ export type RequestReader = (req: HonoRequest) => Promise<unknown> | unknown;
 
 export const jsonBody: RequestReader = (req) => req.json().catch(() => ({}));
 
-/** Absent keys are omitted rather than passed as `undefined`. */
-export function queryParams(...keys: readonly string[]): RequestReader {
-  return (req) => {
-    const params: Record<string, string> = {};
-    for (const key of keys) {
-      const value = req.query(key);
-      if (value !== undefined) params[key] = value;
-    }
-    return params;
-  };
-}
-
 /** Every route validates and fails its input the same way. */
 export function endpoint<Schema extends z.ZodTypeAny, Env extends AnyEnv = AnyEnv>(
   schema: Schema,

--- a/packages/api-core/src/http/headers.ts
+++ b/packages/api-core/src/http/headers.ts
@@ -2,7 +2,7 @@ import type { Context, MiddlewareHandler } from 'hono';
 
 /**
  * What every Worker response carries, written once because three copies drift.
- * `x-robots-tag` is the load-bearing one: `/api/scan?url=…` returns JSON about
+ * `x-robots-tag` is the load-bearing one: scan routes return JSON about
  * somebody else's site, and there is no document to put a meta tag in.
  */
 export function standardHeaders(): MiddlewareHandler {

--- a/packages/api-core/src/http/rateLimit.ts
+++ b/packages/api-core/src/http/rateLimit.ts
@@ -1,0 +1,13 @@
+export interface RateLimiter {
+  limit(input: { readonly key: string }): Promise<{ readonly success: boolean }>;
+}
+
+/** Production abuse boundary. Unbound in tests and local forks, where it fails open. */
+export async function allowedByRateLimit(
+  limiter: RateLimiter | undefined,
+  request: Request,
+): Promise<boolean> {
+  if (limiter === undefined) return true;
+  const client = request.headers.get('cf-connecting-ip') ?? 'unknown';
+  return (await limiter.limit({ key: client })).success;
+}

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -1,10 +1,14 @@
-export { endpoint, jsonBody, queryParams } from './http/endpoint.js';
+export { endpoint, jsonBody } from './http/endpoint.js';
 export { corsFor } from './http/cors.js';
 export { standardHeaders } from './http/headers.js';
+export { allowedByRateLimit } from './http/rateLimit.js';
+export type { RateLimiter } from './http/rateLimit.js';
 export type { RequestReader } from './http/endpoint.js';
 export { NOT_FOUND, toHttpFailure } from './http/errors.js';
 export type { HttpFailure } from './http/errors.js';
 export { PageFetchError } from './services/PageFetchError.js';
 export { InvalidTargetError, TargetResolver } from './services/TargetResolver.js';
+export { SafeFetcher, readText } from './services/SafeFetcher.js';
+export type { SafeFetchResult } from './services/SafeFetcher.js';
 export { ReadingRecorder } from './services/ReadingRecorder.js';
 export type { ReadingTransport, RecorderConfig } from './services/ReadingRecorder.js';

--- a/packages/api-core/src/services/SafeFetcher.ts
+++ b/packages/api-core/src/services/SafeFetcher.ts
@@ -1,0 +1,79 @@
+import { InvalidTargetError, TargetResolver } from './TargetResolver.js';
+
+const REDIRECTS = new Set([301, 302, 303, 307, 308]);
+
+export interface SafeFetchResult {
+  readonly response: Response;
+  readonly url: URL;
+  readonly redirects: number;
+  readonly temporaryRedirect: boolean;
+}
+
+export class SafeFetcher {
+  public constructor(
+    private readonly resolver = new TargetResolver(),
+    private readonly send: typeof fetch = (input, init) => fetch(input, init),
+  ) {}
+
+  public async fetch(
+    input: string | URL,
+    init: RequestInit = {},
+    maxRedirects = 5,
+  ): Promise<SafeFetchResult> {
+    let url = this.resolver.resolve(String(input));
+    let requestInit = init;
+    let redirects = 0;
+    let temporaryRedirect = false;
+    for (;;) {
+      const response = await this.send(url.toString(), { ...requestInit, redirect: 'manual' });
+      if (!REDIRECTS.has(response.status)) return { response, url, redirects, temporaryRedirect };
+      const location = response.headers.get('location');
+      if (location === null) return { response, url, redirects, temporaryRedirect };
+      if (redirects >= maxRedirects) throw new InvalidTargetError('Too many redirects');
+      temporaryRedirect ||= response.status === 302 || response.status === 307;
+      redirects += 1;
+      const next = this.resolver.resolve(new URL(location, url).toString());
+      if (next.origin !== url.origin) requestInit = withoutCredentials(requestInit);
+      url = next;
+    }
+  }
+}
+
+function withoutCredentials(init: RequestInit): RequestInit {
+  const headers = new Headers(init.headers);
+  headers.delete('authorization');
+  headers.delete('proxy-authorization');
+  headers.delete('cookie');
+  headers.delete('apikey');
+  return { ...init, headers };
+}
+
+export async function readText(
+  response: Response,
+  maxBytes: number,
+): Promise<{ text: string; truncated: boolean }> {
+  if (response.body === null) return { text: '', truncated: false };
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  let bytes = 0;
+  let truncated = false;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const remaining = maxBytes - bytes;
+      if (value.byteLength > remaining) {
+        text += decoder.decode(value.subarray(0, Math.max(0, remaining)), { stream: true });
+        truncated = true;
+        await reader.cancel();
+        break;
+      }
+      bytes += value.byteLength;
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return { text: text + decoder.decode(), truncated };
+}

--- a/packages/api-core/src/services/TargetResolver.ts
+++ b/packages/api-core/src/services/TargetResolver.ts
@@ -4,14 +4,8 @@ const BLOCKED_HOSTNAMES = new Set([
   '0.0.0.0',
   '::1',
   'metadata.google.internal',
+  'instance-data.ec2.internal',
 ]);
-const PRIVATE_RANGES = [
-  /^10\./,
-  /^192\.168\./,
-  /^172\.(?:1[6-9]|2\d|3[01])\./,
-  /^169\.254\./,
-  /^127\./,
-];
 
 export class InvalidTargetError extends Error {
   public constructor(message: string) {
@@ -43,9 +37,12 @@ export class TargetResolver {
     if (url.protocol !== 'https:' && url.protocol !== 'http:') {
       throw new InvalidTargetError('Only http and https URLs can be scanned');
     }
+    if (url.username !== '' || url.password !== '') {
+      throw new InvalidTargetError('URLs containing credentials cannot be scanned');
+    }
 
-    const hostname = url.hostname.toLowerCase();
-    if (BLOCKED_HOSTNAMES.has(hostname) || PRIVATE_RANGES.some((range) => range.test(hostname))) {
+    const hostname = url.hostname.toLowerCase().replace(/\.+$/, '');
+    if (BLOCKED_HOSTNAMES.has(hostname) || isNonPublicIp(hostname)) {
       throw new InvalidTargetError('That host is not reachable from the scanner');
     }
     if (!hostname.includes('.')) {
@@ -54,4 +51,76 @@ export class TargetResolver {
 
     return url;
   }
+}
+
+function isNonPublicIp(hostname: string): boolean {
+  const bare =
+    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  const ipv4 = parseIpv4(bare);
+  if (ipv4 !== null) return isNonPublicIpv4(ipv4);
+  if (!bare.includes(':')) return false;
+  const ipv6 = expandIpv6(bare);
+  if (ipv6 === null) return true;
+  const first = ipv6[0] ?? 0;
+  if (ipv6.every((part) => part === 0)) return true;
+  if (ipv6.slice(0, 7).every((part) => part === 0) && ipv6[7] === 1) return true;
+  if ((first & 0xfe00) === 0xfc00 || (first & 0xffc0) === 0xfe80 || (first & 0xff00) === 0xff00)
+    return true;
+  if (first === 0x2001 && [0x0db8, 0x0002, 0x0010].includes(ipv6[1] ?? -1)) return true;
+  if (first === 0x0100 && ipv6.slice(1, 4).every((part) => part === 0)) return true;
+  const mapped = ipv6.slice(0, 5).every((part) => part === 0) && ipv6[5] === 0xffff;
+  const sixth = ipv6[6] ?? 0;
+  const seventh = ipv6[7] ?? 0;
+  return mapped ? isNonPublicIpv4([sixth >> 8, sixth & 0xff, seventh >> 8, seventh & 0xff]) : false;
+}
+
+type Ipv4 = readonly [number, number, number, number];
+
+function parseIpv4(value: string): Ipv4 | null {
+  const parts = value.split('.');
+  if (parts.length !== 4 || parts.some((part) => !/^\d{1,3}$/.test(part))) return null;
+  const octets = parts.map(Number);
+  if (!octets.every((part) => part >= 0 && part <= 255)) return null;
+  return [octets[0] ?? 0, octets[1] ?? 0, octets[2] ?? 0, octets[3] ?? 0];
+}
+
+function isNonPublicIpv4([a, b, c]: Ipv4): boolean {
+  return (
+    a === 0 ||
+    a === 10 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && (b === 0 || b === 168)) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
+  );
+}
+
+function expandIpv6(value: string): number[] | null {
+  const halves = value.split('::');
+  if (halves.length > 2) return null;
+  const left = parseIpv6Parts(halves[0] ?? '');
+  const right = parseIpv6Parts(halves[1] ?? '');
+  if (left === null || right === null) return null;
+  const missing = 8 - left.length - right.length;
+  if ((halves.length === 1 && missing !== 0) || (halves.length === 2 && missing < 1)) return null;
+  return [...left, ...Array.from({ length: missing }, () => 0), ...right];
+}
+
+function parseIpv6Parts(value: string): number[] | null {
+  if (value === '') return [];
+  const result: number[] = [];
+  for (const part of value.split(':')) {
+    const ipv4 = parseIpv4(part);
+    if (ipv4 !== null) {
+      const [a, b, c, d] = ipv4;
+      result.push((a << 8) | b, (c << 8) | d);
+    } else if (/^[\da-f]{1,4}$/i.test(part)) result.push(Number.parseInt(part, 16));
+    else return null;
+  }
+  return result;
 }

--- a/tools/citecheck/README.md
+++ b/tools/citecheck/README.md
@@ -347,9 +347,7 @@ address. The console proxies `/citecheck/api` to the Worker above.
 
 ```
 POST /api/crawl  { "url": "example.com" }      what the client calls
-GET  /api/crawl?url=example.com&depth=2&maxPages=15
 POST /api/scan   { "url": "example.com" }      one page only
-GET  /api/scan?url=example.com
 GET  /api/health
 ```
 

--- a/tools/citecheck/api/src/http/env.ts
+++ b/tools/citecheck/api/src/http/env.ts
@@ -1,3 +1,5 @@
+import type { RateLimiter } from '@lumioguard/api-core';
+
 export interface Env {
   /** Comma-separated origins allowed to call the API. `*` in development. */
   ALLOWED_ORIGINS?: string;
@@ -11,6 +13,7 @@ export interface Env {
 
   /** Required alongside the secret, so a fork cannot post to an API it does not own. */
   LUMIOGUARD_API_BASE_URL?: string;
+  SCAN_RATE_LIMITER?: RateLimiter;
 }
 
 export type Bindings = { Bindings: Env };

--- a/tools/citecheck/api/src/index.ts
+++ b/tools/citecheck/api/src/index.ts
@@ -1,9 +1,9 @@
 import {
   NOT_FOUND,
+  allowedByRateLimit,
   corsFor,
   endpoint,
   jsonBody,
-  queryParams,
   standardHeaders,
   toHttpFailure,
 } from '@lumioguard/api-core';
@@ -25,6 +25,18 @@ const app = new Hono<Bindings>();
 app.use('*', async (context, next) => corsFor(context.env.ALLOWED_ORIGINS)(context, next));
 
 app.use('*', standardHeaders());
+app.use('/api/*', async (context, next) => {
+  if (
+    context.req.path !== '/api/health' &&
+    !(await allowedByRateLimit(context.env.SCAN_RATE_LIMITER, context.req.raw))
+  ) {
+    return context.json(
+      { error: { code: 'rate_limited', message: 'Too many scans. Try again shortly.' } },
+      429,
+    );
+  }
+  await next();
+});
 
 /**
  * Read a page, then record it so the report can hand the reading on. AWAITED
@@ -63,10 +75,8 @@ const crawl = async (
 
 app.get('/api/health', (context) => context.json({ status: 'ok' }));
 
-app.get('/api/scan', endpoint(citationRequestSchema, queryParams('url'), scan));
 app.post('/api/scan', endpoint(citationRequestSchema, jsonBody, scan));
 
-app.get('/api/crawl', endpoint(crawlRequestSchema, queryParams('url', 'depth', 'maxPages'), crawl));
 app.post('/api/crawl', endpoint(crawlRequestSchema, jsonBody, crawl));
 
 app.onError((error, context) => {

--- a/tools/citecheck/api/src/services/PageFetcher.ts
+++ b/tools/citecheck/api/src/services/PageFetcher.ts
@@ -1,4 +1,4 @@
-import { PageFetchError } from '@lumioguard/api-core';
+import { PageFetchError, SafeFetcher, readText } from '@lumioguard/api-core';
 import type { PageInput } from '@lumioguard/citecheck-core';
 
 const USER_AGENT =
@@ -54,6 +54,7 @@ export interface AgentProbe {
  */
 export class PageFetcher {
   private readonly timeoutMs: number;
+  private readonly safeFetcher = new SafeFetcher();
 
   public constructor(options: { timeoutMs?: number } = {}) {
     this.timeoutMs = options.timeoutMs ?? 12_000;
@@ -68,31 +69,8 @@ export class PageFetcher {
    * audit asks and neither survives a followed redirect.
    */
   public async fetchPage(target: URL): Promise<FetchedPage> {
-    let current = target.toString();
-    let redirects = 0;
-    let temporary = false;
-    let response = await this.request(
-      current,
-      USER_AGENT,
-      { accept: 'text/html,*/*' },
-      undefined,
-      'manual',
-    );
-
-    while (isRedirect(response.status) && redirects < MAX_HOPS) {
-      const location = response.headers.get('location');
-      if (location === null) break;
-      temporary = temporary || response.status === 302 || response.status === 307;
-      redirects += 1;
-      current = new URL(location, current).toString();
-      response = await this.request(
-        current,
-        USER_AGENT,
-        { accept: 'text/html,*/*' },
-        undefined,
-        'manual',
-      );
-    }
+    const fetched = await this.request(target.toString(), USER_AGENT, { accept: 'text/html,*/*' });
+    const response = fetched.response;
 
     if (!response.ok) {
       throw new PageFetchError(
@@ -116,17 +94,17 @@ export class PageFetcher {
       if (value !== null) headers[name] = value;
     }
 
-    const url = response.url === '' ? current : response.url;
+    const url = fetched.url.toString();
     return {
       url,
-      html: (await response.text()).slice(0, MAX_HTML_BYTES),
+      html: (await readText(response, MAX_HTML_BYTES)).text,
       headers,
       status: response.status,
       delivery: {
         status: response.status,
-        redirects,
-        requestedUrl: redirects > 0 ? target.toString() : null,
-        temporary,
+        redirects: fetched.redirects,
+        requestedUrl: fetched.redirects > 0 ? target.toString() : null,
+        temporary: fetched.temporaryRedirect,
       },
     };
   }
@@ -141,15 +119,17 @@ export class PageFetcher {
    */
   public async probeAsAgent(target: URL): Promise<AgentProbe | null> {
     try {
-      const response = await this.request(
-        target.toString(),
-        CRAWLER_USER_AGENT,
-        { accept: 'text/html,*/*' },
-        8_000,
-      );
+      const response = (
+        await this.request(
+          target.toString(),
+          CRAWLER_USER_AGENT,
+          { accept: 'text/html,*/*' },
+          8_000,
+        )
+      ).response;
       return {
         status: response.status,
-        html: response.ok ? (await response.text()).slice(0, MAX_HTML_BYTES) : '',
+        html: response.ok ? (await readText(response, MAX_HTML_BYTES)).text : '',
         userAgent: 'GPTBot/1.1',
       };
     } catch {
@@ -160,9 +140,10 @@ export class PageFetcher {
   /** A well-known file at the site root. Absent is an answer, not an error. */
   public async fetchText(url: string): Promise<string | null> {
     try {
-      const response = await this.request(url, USER_AGENT, { accept: 'text/plain,text/*,*/*' });
+      const response = (await this.request(url, USER_AGENT, { accept: 'text/plain,text/*,*/*' }))
+        .response;
       if (!response.ok) return null;
-      return (await response.text()).slice(0, MAX_HTML_BYTES);
+      return (await readText(response, MAX_HTML_BYTES)).text;
     } catch {
       return null;
     }
@@ -173,16 +154,18 @@ export class PageFetcher {
     userAgent: string,
     extraHeaders: Record<string, string>,
     timeoutMs = this.timeoutMs,
-    redirect: 'follow' | 'manual' = 'follow',
-  ): Promise<Response> {
+  ) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      return await fetch(url, {
-        headers: { 'user-agent': userAgent, ...extraHeaders },
-        redirect,
-        signal: controller.signal,
-      });
+      return await this.safeFetcher.fetch(
+        url,
+        {
+          headers: { 'user-agent': userAgent, ...extraHeaders },
+          signal: controller.signal,
+        },
+        MAX_HOPS,
+      );
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         throw new PageFetchError('timeout', `Timed out after ${timeoutMs}ms`);
@@ -195,8 +178,4 @@ export class PageFetcher {
       clearTimeout(timer);
     }
   }
-}
-
-function isRedirect(status: number): boolean {
-  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }

--- a/tools/citecheck/api/wrangler.toml
+++ b/tools/citecheck/api/wrangler.toml
@@ -5,6 +5,11 @@ compatibility_date = "2024-12-18"
 [vars]
 ALLOWED_ORIGINS = "*"
 
+[[ratelimits]]
+name = "SCAN_RATE_LIMITER"
+namespace_id = "1003"
+simple = { limit = 6, period = 60 }
+
 [env.production]
 name = "lumioguard-citecheck-api"
 
@@ -18,3 +23,8 @@ name = "lumioguard-citecheck-api"
 # hosts only this deployment owns. Empty blocks every browser origin, so a
 # deploy that forgets them fails closed.
 ALLOWED_ORIGINS = ""
+
+[[env.production.ratelimits]]
+name = "SCAN_RATE_LIMITER"
+namespace_id = "1003"
+simple = { limit = 6, period = 60 }

--- a/tools/leakpeek/README.md
+++ b/tools/leakpeek/README.md
@@ -122,7 +122,6 @@ address. The console proxies `/leakpeek/api` to the Worker above.
 
 ```
 POST /api/scan   { "url": "example.com" }
-GET  /api/scan?url=example.com
 GET  /api/health
 ```
 

--- a/tools/leakpeek/api/src/__tests__/probe-runner.test.ts
+++ b/tools/leakpeek/api/src/__tests__/probe-runner.test.ts
@@ -25,12 +25,7 @@ function record(responder: (url: string) => { status: number; body?: string }): 
     vi.fn(async (url: string, init?: RequestInit) => {
       sent.push({ url: String(url), method: init?.method, body: init?.body });
       const { status, body = '' } = responder(String(url));
-      return {
-        status,
-        ok: status >= 200 && status < 300,
-        text: async () => body,
-        json: async () => JSON.parse(body || 'null'),
-      };
+      return new Response(body, { status });
     }),
   );
   return sent;

--- a/tools/leakpeek/api/src/http/env.ts
+++ b/tools/leakpeek/api/src/http/env.ts
@@ -1,3 +1,5 @@
+import type { RateLimiter } from '@lumioguard/api-core';
+
 export interface Env {
   /** Comma-separated origins allowed to call the API. `*` in development. */
   ALLOWED_ORIGINS?: string;
@@ -11,6 +13,7 @@ export interface Env {
 
   /** Unset falls back to production; point it at 127.0.0.1:8787 in dev. */
   LUMIOGUARD_API_BASE_URL?: string;
+  SCAN_RATE_LIMITER?: RateLimiter;
 }
 
 export type Bindings = { Bindings: Env };

--- a/tools/leakpeek/api/src/index.ts
+++ b/tools/leakpeek/api/src/index.ts
@@ -1,4 +1,10 @@
-import { corsFor, endpoint, jsonBody, queryParams, standardHeaders } from '@lumioguard/api-core';
+import {
+  allowedByRateLimit,
+  corsFor,
+  endpoint,
+  jsonBody,
+  standardHeaders,
+} from '@lumioguard/api-core';
 import { NOT_FOUND, toHttpFailure } from '@lumioguard/api-core';
 import { type ExposureRequest, exposureRequestSchema } from '@lumioguard/shared';
 import { type Context, Hono } from 'hono';
@@ -13,6 +19,15 @@ const app = new Hono<Bindings>();
 app.use('*', async (context, next) => corsFor(context.env.ALLOWED_ORIGINS)(context, next));
 
 app.use('*', standardHeaders());
+app.use('/api/scan', async (context, next) => {
+  if (!(await allowedByRateLimit(context.env.SCAN_RATE_LIMITER, context.req.raw))) {
+    return context.json(
+      { error: { code: 'rate_limited', message: 'Too many scans. Try again shortly.' } },
+      429,
+    );
+  }
+  await next();
+});
 
 /**
  * Read a site, then record it so the report can hand the reading on. AWAITED
@@ -34,7 +49,6 @@ const scan = async (input: ExposureRequest, context: Context<Bindings>): Promise
 
 app.get('/api/health', (context) => context.json({ status: 'ok' }));
 
-app.get('/api/scan', endpoint(exposureRequestSchema, queryParams('url'), scan));
 app.post('/api/scan', endpoint(exposureRequestSchema, jsonBody, scan));
 
 app.onError((error, context) => {

--- a/tools/leakpeek/api/src/services/PageFetcher.ts
+++ b/tools/leakpeek/api/src/services/PageFetcher.ts
@@ -1,4 +1,4 @@
-import { PageFetchError } from '@lumioguard/api-core';
+import { PageFetchError, SafeFetcher, readText } from '@lumioguard/api-core';
 import type { FetchedScript } from '@lumioguard/leakpeek-core';
 
 const USER_AGENT =
@@ -24,6 +24,7 @@ const KEEP_HEADERS = [
 
 const MAX_SCRIPTS = 8;
 const MAX_SCRIPT_BYTES = 1_500_000;
+const MAX_HTML_BYTES = 2_000_000;
 
 interface FetchedPage {
   readonly url: string;
@@ -41,19 +42,21 @@ interface FetchedPage {
  */
 export class PageFetcher {
   private readonly timeoutMs: number;
+  private readonly safeFetcher = new SafeFetcher();
 
   public constructor(options: { timeoutMs?: number } = {}) {
     this.timeoutMs = options.timeoutMs ?? 12_000;
   }
 
   public async fetchPage(target: URL): Promise<FetchedPage> {
-    const response = await this.request(target.toString(), { accept: 'text/html,*/*' });
+    const fetched = await this.request(target.toString(), { accept: 'text/html,*/*' });
+    const response = fetched.response;
     if (!response.ok) {
       throw new PageFetchError('upstream_error', `Upstream responded ${response.status}`);
     }
 
-    const html = await response.text();
-    const finalUrl = response.url === '' ? target.toString() : response.url;
+    const html = (await readText(response, MAX_HTML_BYTES)).text;
+    const finalUrl = fetched.url.toString();
 
     const headers: Record<string, string> = {};
     for (const name of KEEP_HEADERS) {
@@ -81,9 +84,9 @@ export class PageFetcher {
       srcs.map(async (src) => {
         try {
           const absolute = new URL(src, baseUrl);
-          const response = await this.request(absolute.toString(), {}, 8_000);
+          const response = (await this.request(absolute.toString(), {}, 8_000)).response;
           if (!response.ok) return null;
-          const body = (await response.text()).slice(0, MAX_SCRIPT_BYTES);
+          const body = (await readText(response, MAX_SCRIPT_BYTES)).text;
           return { url: absolute.toString(), body } satisfies FetchedScript;
         } catch {
           // A script that will not load is not a scan failure.
@@ -99,13 +102,12 @@ export class PageFetcher {
     url: string,
     extraHeaders: Record<string, string>,
     timeoutMs = this.timeoutMs,
-  ): Promise<Response> {
+  ) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      return await fetch(url, {
+      return await this.safeFetcher.fetch(url, {
         headers: { 'user-agent': USER_AGENT, ...extraHeaders },
-        redirect: 'follow',
         signal: controller.signal,
       });
     } catch (error) {

--- a/tools/leakpeek/api/src/services/ProbeRunner.ts
+++ b/tools/leakpeek/api/src/services/ProbeRunner.ts
@@ -1,3 +1,4 @@
+import { SafeFetcher, readText } from '@lumioguard/api-core';
 import {
   COMMON_TABLES,
   EXPOSED_FILE_CHECKS,
@@ -24,8 +25,10 @@ import {
 const MAX_RLS_FINDINGS = 5;
 const PROBE_TIMEOUT_MS = 6_000;
 const MAX_SOURCE_MAP_CHECKS = 4;
+const MAX_PROBE_BYTES = 1_000_000;
 
 export class ProbeRunner {
+  private readonly safeFetcher = new SafeFetcher();
   public async probeSupabase(target: SupabaseTarget): Promise<ExposureFinding[]> {
     const headers = supabaseProbeHeaders(target);
     const findings: ExposureFinding[] = [];
@@ -54,7 +57,7 @@ export class ProbeRunner {
     for (const check of EXPOSED_FILE_CHECKS) {
       try {
         const response = await this.get(new URL(check.path, origin).toString(), {});
-        const body = response.status === 200 ? (await response.text()).slice(0, 4000) : '';
+        const body = response.status === 200 ? (await readText(response, 4000)).text : '';
         const finding = interpretExposedFile(check, response.status, body);
         if (finding !== null) findings.push(finding);
       } catch {
@@ -72,7 +75,8 @@ export class ProbeRunner {
     try {
       const response = await this.get(url, headers);
       if (response.status !== 200) return { status: response.status, rows: null };
-      const body: unknown = await response.json().catch(() => null);
+      const text = (await readText(response, MAX_PROBE_BYTES)).text;
+      const body: unknown = parseJson(text);
       return { status: 200, rows: Array.isArray(body) ? body : null };
     } catch {
       return null;
@@ -84,7 +88,7 @@ export class ProbeRunner {
       const response = await this.get(url, {});
       if (response.status !== 200) return false;
       // Confirm it is actually a map, not an SPA's HTML 200 for an unknown path.
-      const head = (await response.text()).slice(0, 200);
+      const head = (await readText(response, 200)).text;
       return head.includes('"version"') && head.includes('"sources"');
     } catch {
       return false;
@@ -96,14 +100,23 @@ export class ProbeRunner {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
     try {
-      return await fetch(url, {
-        method: 'GET',
-        headers,
-        redirect: 'follow',
-        signal: controller.signal,
-      });
+      return (
+        await this.safeFetcher.fetch(url, {
+          method: 'GET',
+          headers,
+          signal: controller.signal,
+        })
+      ).response;
     } finally {
       clearTimeout(timer);
     }
+  }
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
   }
 }

--- a/tools/leakpeek/api/wrangler.toml
+++ b/tools/leakpeek/api/wrangler.toml
@@ -5,6 +5,11 @@ compatibility_date = "2024-12-18"
 [vars]
 ALLOWED_ORIGINS = "*"
 
+[[ratelimits]]
+name = "SCAN_RATE_LIMITER"
+namespace_id = "1001"
+simple = { limit = 6, period = 60 }
+
 [env.production]
 name = "lumioguard-leakpeek-api"
 
@@ -18,3 +23,8 @@ name = "lumioguard-leakpeek-api"
 # hosts only this deployment owns. Empty blocks every browser origin, so a
 # deploy that forgets them fails closed.
 ALLOWED_ORIGINS = ""
+
+[[env.production.ratelimits]]
+name = "SCAN_RATE_LIMITER"
+namespace_id = "1001"
+simple = { limit = 6, period = 60 }

--- a/tools/slopmeter/api/src/http/env.ts
+++ b/tools/slopmeter/api/src/http/env.ts
@@ -1,3 +1,5 @@
+import type { RateLimiter } from '@lumioguard/api-core';
+
 export interface Env {
   /** Comma-separated origins allowed to call the API. `*` in development. */
   ALLOWED_ORIGINS?: string;
@@ -13,6 +15,7 @@ export interface Env {
    * Recording is a side effect of a reading, never a precondition for one.
    */
   SLOPMETER_INGEST_SECRET?: string;
+  SCAN_RATE_LIMITER?: RateLimiter;
 }
 
 export type Bindings = { Bindings: Env };

--- a/tools/slopmeter/api/src/index.ts
+++ b/tools/slopmeter/api/src/index.ts
@@ -1,4 +1,10 @@
-import { corsFor, endpoint, jsonBody, queryParams, standardHeaders } from '@lumioguard/api-core';
+import {
+  allowedByRateLimit,
+  corsFor,
+  endpoint,
+  jsonBody,
+  standardHeaders,
+} from '@lumioguard/api-core';
 import { NOT_FOUND, toHttpFailure } from '@lumioguard/api-core';
 import {
   type AnalyzeRequest,
@@ -22,6 +28,18 @@ const app = new Hono<Bindings>();
 app.use('*', async (context, next) => corsFor(context.env.ALLOWED_ORIGINS)(context, next));
 
 app.use('*', standardHeaders());
+app.use('/api/*', async (context, next) => {
+  if (
+    context.req.path !== '/api/health' &&
+    !(await allowedByRateLimit(context.env.SCAN_RATE_LIMITER, context.req.raw))
+  ) {
+    return context.json(
+      { error: { code: 'rate_limited', message: 'Too many scans. Try again shortly.' } },
+      429,
+    );
+  }
+  await next();
+});
 
 const scanPage = (input: ScanRequest): Promise<unknown> =>
   getContainer().scanService.scanUrl(input.url);
@@ -51,13 +69,8 @@ const analyze = (input: AnalyzeRequest): unknown =>
 /** Liveness only. */
 app.get('/api/health', (context) => context.json({ status: 'ok' }));
 
-app.get('/api/scan', endpoint(scanRequestSchema, queryParams('url'), scanPage));
 app.post('/api/scan', endpoint(scanRequestSchema, jsonBody, scanPage));
 
-app.get(
-  '/api/crawl',
-  endpoint(crawlRequestSchema, queryParams('url', 'depth', 'maxPages'), crawlSite),
-);
 app.post('/api/crawl', endpoint(crawlRequestSchema, jsonBody, crawlSite));
 
 app.post('/api/analyze', endpoint(analyzeRequestSchema, jsonBody, analyze));

--- a/tools/slopmeter/api/src/services/PageFetcher.ts
+++ b/tools/slopmeter/api/src/services/PageFetcher.ts
@@ -1,4 +1,4 @@
-import { PageFetchError } from '@lumioguard/api-core';
+import { PageFetchError, SafeFetcher, readText } from '@lumioguard/api-core';
 import { PageSnapshot } from '@lumioguard/slopmeter-core';
 
 const USER_AGENT =
@@ -14,6 +14,7 @@ const KEEP_HEADERS = [
 
 const MAX_STYLESHEETS = 6;
 const MAX_CSS_BYTES = 400_000;
+const MAX_HTML_BYTES = 2_000_000;
 
 interface PageFetcherOptions {
   readonly timeoutMs?: number;
@@ -25,15 +26,17 @@ interface PageFetcherOptions {
  */
 export class PageFetcher {
   private readonly timeoutMs: number;
+  private readonly safeFetcher = new SafeFetcher();
 
   public constructor(options: PageFetcherOptions = {}) {
     this.timeoutMs = options.timeoutMs ?? 12_000;
   }
 
   public async fetchSnapshot(target: URL): Promise<PageSnapshot> {
-    const response = await this.request(target.toString(), {
+    const fetched = await this.request(target.toString(), {
       accept: 'text/html,*/*',
     });
+    const response = fetched.response;
 
     if (!response.ok) {
       throw new PageFetchError('upstream_error', `Upstream responded ${response.status}`);
@@ -47,7 +50,7 @@ export class PageFetcher {
       );
     }
 
-    const html = await response.text();
+    const html = (await readText(response, MAX_HTML_BYTES)).text;
     const headers: Record<string, string> = {};
     for (const name of KEEP_HEADERS) {
       const value = response.headers.get(name);
@@ -55,9 +58,9 @@ export class PageFetcher {
     }
 
     return PageSnapshot.create({
-      url: response.url === '' ? target.toString() : response.url,
+      url: fetched.url.toString(),
       html,
-      stylesheets: await this.fetchStylesheets(html, response.url || target.toString()),
+      stylesheets: await this.fetchStylesheets(html, fetched.url.toString()),
       headers,
     });
   }
@@ -72,9 +75,9 @@ export class PageFetcher {
       hrefs.map(async (href) => {
         try {
           const absolute = new URL(href, baseUrl);
-          const response = await this.request(absolute.toString(), {}, 8_000);
+          const response = (await this.request(absolute.toString(), {}, 8_000)).response;
           if (!response.ok) return null;
-          return (await response.text()).slice(0, MAX_CSS_BYTES);
+          return (await readText(response, MAX_CSS_BYTES)).text;
         } catch {
           // A stylesheet that will not load is not a scan failure.
           return null;
@@ -89,13 +92,12 @@ export class PageFetcher {
     url: string,
     extraHeaders: Record<string, string>,
     timeoutMs = this.timeoutMs,
-  ): Promise<Response> {
+  ) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      return await fetch(url, {
+      return await this.safeFetcher.fetch(url, {
         headers: { 'user-agent': USER_AGENT, ...extraHeaders },
-        redirect: 'follow',
         signal: controller.signal,
       });
     } catch (error) {

--- a/tools/slopmeter/api/wrangler.toml
+++ b/tools/slopmeter/api/wrangler.toml
@@ -13,6 +13,11 @@ compatibility_date = "2024-12-18"
 [vars]
 ALLOWED_ORIGINS = "*"
 
+[[ratelimits]]
+name = "SCAN_RATE_LIMITER"
+namespace_id = "1002"
+simple = { limit = 6, period = 60 }
+
 [env.production]
 name = "lumioguard-slopmeter-api"
 
@@ -29,3 +34,8 @@ name = "lumioguard-slopmeter-api"
 # hosts only this deployment owns. Empty blocks every browser origin, so a
 # deploy that forgets them fails closed.
 ALLOWED_ORIGINS = ""
+
+[[env.production.ratelimits]]
+name = "SCAN_RATE_LIMITER"
+namespace_id = "1002"
+simple = { limit = 6, period = 60 }


### PR DESCRIPTION
## Summary

- validate every outbound URL and redirect through one SSRF boundary
- stream responses to byte limits and strip credentials on cross-origin redirects
- add Worker rate limits and make expensive routes POST-only
- pin CI actions and improve open-source documentation and templates

## Verification

- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build