### PR TITLE
feat(console): a panel under the ask on each reading page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ Thumbs.db
 .idea/
 .vscode/*
 !.vscode/extensions.json
+
+# Keyword research pulled from DataForSEO. Paid data, and the account
+# response carries a login and a balance: this repo is public.
+seo-data/

--- a/apps/console/ai-slop-check/leaderboard.html
+++ b/apps/console/ai-slop-check/leaderboard.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Written at build time from `src/copy.ts` and the tool catalogue, so
+         what a crawler is told and what a reader is shown come from one
+         source. Removing the anchor below fails the build. See `build/seo.ts`. -->
+    <!--seo:head-->
+    <!--seo:chrome-->
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/console/build/__tests__/entries.test.ts
+++ b/apps/console/build/__tests__/entries.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { CATALOGUE, SCAN_SLUG } from '../../src/tools/catalogue.js';
+import { CATALOGUE, SCAN_SLUG, leaderboardPath } from '../../src/tools/catalogue.js';
 
 const ROOT = new URL('../../', import.meta.url);
 
@@ -17,6 +17,12 @@ const ENTRIES = [
 ];
 
 describe('the entry documents', () => {
+  it('keeps the board under the reading it ranks', () => {
+    // Nested on purpose: /ai-slop-check/leaderboard is served from
+    // ai-slop-check/leaderboard.html with a 200, and belongs to that reading.
+    expect(read(`.${leaderboardPath()}.html`)).toBe(read('index.html'));
+  });
+
   it('is one per page, and no more', () => {
     // `vite.config.ts` builds its input map from the catalogue, so a reading
     // added without its document fails deep inside Rollup with a missing path.

--- a/apps/console/build/__tests__/wellKnown.test.ts
+++ b/apps/console/build/__tests__/wellKnown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { PAGES } from '../../src/pages.js';
-import { CATALOGUE, SCAN_SLUG } from '../../src/tools/catalogue.js';
+import { CATALOGUE, SCAN_SLUG, leaderboardPath } from '../../src/tools/catalogue.js';
 import { llmsTxt, robotsTxt, sitemapXml } from '../wellKnown.js';
 
 const ORIGIN = 'https://example.test';
@@ -68,6 +68,7 @@ describe('sitemap.xml', () => {
     expect([...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1])).toEqual([
       `${ORIGIN}/`,
       `${ORIGIN}/${SCAN_SLUG}`,
+      `${ORIGIN}${leaderboardPath()}`,
       ...CATALOGUE.map((tool) => `${ORIGIN}/${tool.slug}`),
       ...PAGES.map((page) => `${ORIGIN}${page.path}`),
     ]);

--- a/apps/console/build/head.ts
+++ b/apps/console/build/head.ts
@@ -1,6 +1,6 @@
-import { DESCRIPTION, NAME, PUBLISHER, SCAN, TITLE } from '../src/copy.js';
+import { DESCRIPTION, LEADERBOARD, NAME, PUBLISHER, SCAN, TITLE } from '../src/copy.js';
 import type { PageLink } from '../src/pages.js';
-import { CATALOGUE, SCAN_SLUG, type ToolCopy } from '../src/tools/catalogue.js';
+import { CATALOGUE, SCAN_SLUG, type ToolCopy, leaderboardPath } from '../src/tools/catalogue.js';
 import { escapeHtml } from './html.js';
 import { type Site, absolute } from './site.js';
 
@@ -29,6 +29,13 @@ export const SCAN_PAGE: PageLink = {
   path: `/${SCAN_SLUG}`,
   title: `${SCAN.headline} · ${NAME}`,
   description: SCAN.description,
+};
+
+/** What has been read, ranked. Its own promise, so its own title and canonical. */
+export const LEADERBOARD_PAGE: PageLink = {
+  path: leaderboardPath(),
+  title: `${LEADERBOARD.headline} · ${NAME}`,
+  description: LEADERBOARD.description,
 };
 
 /** One reading's own page, where it runs alone. */

--- a/apps/console/build/seo.ts
+++ b/apps/console/build/seo.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { type Plugin, type ResolvedConfig, type UserConfig, loadEnv } from 'vite';
 import { pageForPath } from '../src/tools/catalogue.js';
-import { HOME, OG_IMAGE, SCAN_PAGE, headTags, toolPage } from './head.js';
+import { HOME, LEADERBOARD_PAGE, OG_IMAGE, SCAN_PAGE, headTags, toolPage } from './head.js';
 import { CONTENT_PAGES } from './pages/content.js';
 import { renderPage } from './pages/render.js';
 import { staticShell } from './shell.js';
@@ -148,7 +148,13 @@ export function seo(): Plugin {
         // so, and it matches the slug the app reads back off the path.
         const page = pageForPath(ctx.path);
         const meta =
-          page.kind === 'tool' ? toolPage(page.tool) : page.kind === 'scan' ? SCAN_PAGE : HOME;
+          page.kind === 'tool'
+            ? toolPage(page.tool)
+            : page.kind === 'scan'
+              ? SCAN_PAGE
+              : page.kind === 'leaderboard'
+                ? LEADERBOARD_PAGE
+                : HOME;
 
         const withHead = replaceOnce(html, HEAD_ANCHOR, headTags(meta, where, card !== null));
         const withChrome = replaceOnce(withHead, CHROME_ANCHOR, chrome(where?.path ?? ''));

--- a/apps/console/build/shell.ts
+++ b/apps/console/build/shell.ts
@@ -1,4 +1,4 @@
-import { EXAMPLES, HEADLINE_TEXT, HOW_IT_WORKS, NAME, PUBLISHER, SCAN } from '../src/copy.js';
+import { EXAMPLES, HEADLINE_TEXT, LEADERBOARD, NAME, PUBLISHER, SCAN, beats } from '../src/copy.js';
 import { CATALOGUE, type ConsolePage } from '../src/tools/catalogue.js';
 import { escapeHtml } from './html.js';
 
@@ -30,7 +30,9 @@ export function staticShell(mount: string, page: ConsolePage = { kind: 'choose' 
       ? page.tool.headline
       : page.kind === 'scan'
         ? SCAN.headline
-        : HEADLINE_TEXT;
+        : page.kind === 'leaderboard'
+          ? LEADERBOARD.headline
+          : HEADLINE_TEXT;
   // The chooser is the only page that links onward, and it links to every
   // reading: it is the one document a crawler reaches the rest from.
   const choices = CATALOGUE.map(
@@ -38,7 +40,8 @@ export function staticShell(mount: string, page: ConsolePage = { kind: 'choose' 
       `<li><a href="${mount}/${tool.slug}">${escapeHtml(tool.label)}</a>. ${escapeHtml(tool.summary)}</li>`,
   ).join('\n          ');
 
-  const beats = [HOW_IT_WORKS.paste, HOW_IT_WORKS.read, HOW_IT_WORKS.result]
+  const how = beats(page.kind === 'tool' ? page.tool.checks : undefined);
+  const steps = [how.paste, how.read, how.result]
     .map((beat) => `<li>${escapeHtml(beat)}</li>`)
     .join('\n          ');
 
@@ -64,7 +67,7 @@ ${
 }
         <h2>How it works</h2>
         <ol>
-          ${beats}
+          ${steps}
         </ol>
 
         <h2>Try one</h2>

--- a/apps/console/build/wellKnown.ts
+++ b/apps/console/build/wellKnown.ts
@@ -1,5 +1,5 @@
 import { DESCRIPTION, EXAMPLES, NAME } from '../src/copy.js';
-import { CATALOGUE, SCAN_SLUG } from '../src/tools/catalogue.js';
+import { CATALOGUE, SCAN_SLUG, leaderboardPath } from '../src/tools/catalogue.js';
 import { CONTENT_PAGES } from './pages/content.js';
 import { type Site, absolute } from './site.js';
 
@@ -36,6 +36,7 @@ export function sitemapXml(where: Site): string {
   const paths = [
     '/',
     `/${SCAN_SLUG}`,
+    leaderboardPath(),
     ...CATALOGUE.map((tool) => `/${tool.slug}`),
     ...CONTENT_PAGES.map((page) => page.meta.path),
   ];

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -10,12 +10,17 @@ import {
   ThemeToggle,
   useTheme,
 } from '@lumioguard/ui';
-import { EXAMPLES, HEADLINE, HOW_IT_WORKS, PUBLISHER } from './copy.js';
+import type { ReactNode } from 'react';
+import { EXAMPLES, HEADLINE, PUBLISHER, beats } from './copy.js';
+import { LeaderboardPreview } from './features/leaderboard/LeaderboardPreview.js';
+import { LeaderboardView } from './features/leaderboard/LeaderboardView.js';
 import { ConsoleReport } from './features/report/ConsoleReport.js';
 import { useConsoleRoute } from './features/scan/useConsoleRoute.js';
 import { ToolPicker } from './features/select/ToolPicker.js';
-import type { ToolCopy } from './tools/catalogue.js';
+import { LEADERBOARD_TOOL, type ToolCopy } from './tools/catalogue.js';
+import { WhyItMatters } from './tools/citecheck/WhyItMatters.js';
 import { TOOLS } from './tools/index.js';
+import { CommonIssues } from './tools/leakpeek/CommonIssues.js';
 import { type ToolDescriptor, toolsById } from './tools/registry.js';
 
 function Masthead(): JSX.Element {
@@ -36,6 +41,14 @@ function Masthead(): JSX.Element {
 
 /** Vite's asset base, without its trailing slash. `''` when served at a root. */
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+/** What sits under the address field, which is the pinned reading's business. */
+function belowAsk(pinned: string | undefined): ReactNode {
+  if (pinned === LEADERBOARD_TOOL) return <LeaderboardPreview />;
+  if (pinned === 'leakpeek') return <CommonIssues />;
+  if (pinned === 'citecheck') return <WhyItMatters />;
+  return undefined;
+}
 
 /** The h1 is the one place set in Archivo: the hand was hard to read at 48px. */
 const H1 =
@@ -119,11 +132,14 @@ function AskView({
   toolIds,
   onSelect,
   pinned,
+  below,
 }: {
   readonly onScan: (address: string) => void;
   readonly toolIds: readonly string[];
   readonly onSelect: (ids: readonly string[]) => void;
   readonly pinned: ToolCopy | null;
+  /** Drawn under the ask, in the SAME grid: a second grid centres itself apart. */
+  readonly below?: ReactNode;
 }): JSX.Element {
   return (
     <PanelGrid centred>
@@ -145,10 +161,11 @@ function AskView({
           </div>
 
           <aside className="mt-7 flex items-center self-stretch lg:mt-0">
-            <HowItWorks labels={HOW_IT_WORKS} />
+            <HowItWorks labels={beats(pinned?.checks)} />
           </aside>
         </div>
       </Panel>
+      {below}
     </PanelGrid>
   );
 }
@@ -171,16 +188,26 @@ function Colophon(): JSX.Element {
 }
 
 export function App(): JSX.Element {
-  const { address, toolIds, pinned, chooser, open, select, clear } = useConsoleRoute();
+  const { address, toolIds, pinned, chooser, board, open, select, clear } = useConsoleRoute();
   const tools = toolsById(TOOLS, toolIds);
 
   return (
     <div className="flex min-h-screen flex-col">
       <Masthead />
-      {chooser ? (
+      {board ? (
+        <LeaderboardView />
+      ) : chooser ? (
         <ChooseView />
       ) : address === null ? (
-        <AskView onScan={open} toolIds={toolIds} onSelect={select} pinned={pinned} />
+        <AskView
+          onScan={open}
+          toolIds={toolIds}
+          onSelect={select}
+          pinned={pinned}
+          // Each reading's own panel under the ask: the board is Slopmeter's,
+          // the common issues are Leakpeek's, and the third has neither.
+          below={belowAsk(pinned?.id)}
+        />
       ) : (
         // No picker here. What to read is asked once, before the reading; on the
         // report it was a control at the end of a page nobody scrolls to, for a

--- a/apps/console/src/copy.ts
+++ b/apps/console/src/copy.ts
@@ -44,15 +44,39 @@ export const EXAMPLES: readonly string[] = ['apple.com', 'figma.com', 'nytimes.c
  */
 export const HOW_IT_WORKS = {
   paste: 'Paste a URL',
+  /** Where every reading runs. A tool's own page says what THAT one looks for. */
   read: 'Every reading you picked runs at once, each against its own engine',
-  result: 'One verdict, the worst of them, with each reading underneath',
+  result: 'You get the verdict with the reasons',
 } as const;
+
+/**
+ * The three beats, with the middle line this reading's own where there is one.
+ * Written once: the app and the prerendered shell both read it, and typed into
+ * each they could tell a visitor two different things about the same page.
+ */
+export function beats(checks?: string): {
+  readonly paste: string;
+  readonly read: string;
+  readonly result: string;
+} {
+  return { ...HOW_IT_WORKS, read: checks ?? HOW_IT_WORKS.read };
+}
 
 /** The all-readings page, which is a different promise from the chooser's. */
 export const SCAN = {
   headline: 'Read a site with every check at once',
   description:
     'Run all three readings on one URL and land on a single verdict: the worst of them, with each reading underneath it.',
+} as const;
+
+/**
+ * The board of what has been read. Its own promise, so its own title: a visitor
+ * arriving here wants the ranking, not a scanner.
+ */
+export const LEADERBOARD = {
+  headline: 'Which sites look least like every other AI site?',
+  description:
+    'Every site read so far, ranked both ways: the most original, and the ones still wearing the template. One row per site, its latest reading.',
 } as const;
 
 /** Who the colophon credits, and who the structured data names as publisher. */

--- a/apps/console/src/features/leaderboard/LeaderboardClient.ts
+++ b/apps/console/src/features/leaderboard/LeaderboardClient.ts
@@ -1,0 +1,41 @@
+import {
+  type LeaderboardResponse,
+  type LeaderboardSide,
+  leaderboardResponseSchema,
+} from '@lumioguard/shared';
+import { apiBase } from '../../tools/apiBase.js';
+
+/**
+ * The board, read through Slopmeter's Worker.
+ *
+ * Not from LumioGuard directly: this bundle is open source and carries no
+ * LumioGuard address, and the Worker already holds one. Where a reading returns
+ * an error the visitor must act on, an unreadable board is just an empty panel,
+ * so this answers null rather than throwing.
+ */
+export class LeaderboardClient {
+  private readonly base: string;
+
+  public constructor(base: string = apiBase('slopmeter')) {
+    this.base = base;
+  }
+
+  public async page(
+    side: LeaderboardSide,
+    page: number,
+    signal?: AbortSignal,
+  ): Promise<LeaderboardResponse | null> {
+    try {
+      const response = await fetch(`${this.base}/api/leaderboard?side=${side}&page=${page}`, {
+        signal,
+      });
+      if (!response.ok) return null;
+      // Validated, not cast: a shape change should surface here rather than as
+      // an undefined inside a table row.
+      const parsed = leaderboardResponseSchema.safeParse(await response.json());
+      return parsed.success ? parsed.data : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/console/src/features/leaderboard/LeaderboardPreview.tsx
+++ b/apps/console/src/features/leaderboard/LeaderboardPreview.tsx
@@ -1,0 +1,117 @@
+import type { LeaderboardRow } from '@lumioguard/shared';
+import { MarkTemplate, Panel, PanelHead } from '@lumioguard/ui';
+import { leaderboardPath } from '../../tools/catalogue.js';
+import { Rank } from './Rank.js';
+import { useBoard } from './useBoard.js';
+
+/** A taste, not the board. Five keeps the panel under the fold on a laptop. */
+const SHOWN = 5;
+
+/** Vite's asset base, without its trailing slash. `''` when served at a root. */
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+/**
+ * Presentational: the rows are read ONCE by the panel and handed down. Reading
+ * them here as well put four requests in flight for two lists, and whichever
+ * pair lost the race rendered an empty column.
+ */
+function Side({
+  band,
+  rows,
+}: { readonly band: string; readonly rows: readonly LeaderboardRow[] }): JSX.Element {
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="m-0 font-hand text-16 text-ink-3">{band}</p>
+      <ol className="m-0 mt-2 list-none p-0">
+        {rows.map((row, index) => (
+          <Rank key={row.host} place={index + 1} row={row} />
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+/**
+ * The board in miniature, under the address field. Drawn only once a side has
+ * something: an empty board should show nothing here rather than two columns of
+ * apology above the fold.
+ */
+export function LeaderboardPreview(): JSX.Element | null {
+  const best = useBoard('best', 1);
+  const worst = useBoard('worst', 1);
+
+  // The band names come from the API, so this panel and the meter a visitor
+  // just read call the same score the same thing.
+  const sides = [best.data, worst.data].map((page) => ({
+    band: page?.band ?? '',
+    rows: page?.rows.slice(0, SHOWN) ?? [],
+  }));
+  if (sides.every((side) => side.rows.length === 0)) {
+    // Silent when the board is genuinely empty: a young board should not put an
+    // apology above the fold. NOT silent when it could not be read, because the
+    // two looked identical and an outage read as a missing feature.
+    if (!(best.failed && worst.failed)) return null;
+
+    return (
+      <Panel hand="c" span={12} className="mt-6">
+        {/* The heading IS the way through, opened in its own tab: a reader here
+          came to scan a site, and the board should not take the page from them. */}
+        <PanelHead
+          title="Leaderboard"
+          mark={<MarkTemplate />}
+          trailing={
+            <a
+              href={`${BASE}${leaderboardPath()}`}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="shrink-0 font-sans text-14 text-hand underline underline-offset-2 hover:no-underline"
+            >
+              See the whole board
+            </a>
+          }
+        />
+        <p className="mt-4 text-body text-ink-2">
+          The board could not be read.{' '}
+          <button
+            type="button"
+            className="underline underline-offset-2 hover:text-hand"
+            onClick={() => {
+              best.retry();
+              worst.retry();
+            }}
+          >
+            Try again
+          </button>
+        </p>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel hand="c" span={12} className="mt-6">
+      {/* The heading IS the way through, opened in its own tab: a reader here
+          came to scan a site, and the board should not take the page from them. */}
+      <PanelHead
+        title="Leaderboard"
+        mark={<MarkTemplate />}
+        trailing={
+          <a
+            href={`${BASE}${leaderboardPath()}`}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="shrink-0 font-sans text-14 text-hand underline underline-offset-2 hover:no-underline"
+          >
+            See the whole board
+          </a>
+        }
+      />
+      <div className="mt-4 flex flex-col gap-6 lg:flex-row lg:gap-[46px]">
+        {sides.map((side) =>
+          side.rows.length === 0 ? null : (
+            <Side key={side.band} band={side.band} rows={side.rows} />
+          ),
+        )}
+      </div>
+    </Panel>
+  );
+}

--- a/apps/console/src/features/leaderboard/LeaderboardView.tsx
+++ b/apps/console/src/features/leaderboard/LeaderboardView.tsx
@@ -1,0 +1,126 @@
+import type { LeaderboardSide } from '@lumioguard/shared';
+import { Panel, PanelGrid, PanelHead } from '@lumioguard/ui';
+import { useState } from 'react';
+import { LEADERBOARD_TOOL, toolCopy } from '../../tools/catalogue.js';
+import { Rank } from './Rank.js';
+import { useBoard } from './useBoard.js';
+
+/** Vite's asset base, without its trailing slash. `''` when served at a root. */
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+/** What the column is, in plain words. The band it filtered on sits beneath. */
+const TITLE: Record<LeaderboardSide, string> = {
+  best: 'Highest scoring',
+  worst: 'Lowest scoring',
+};
+
+/** An empty band and an unreadable one are different facts, and read as such. */
+const EMPTY = 'No site has landed in this band yet.';
+const UNREADABLE = 'The board could not be read.';
+
+const STEP =
+  'rounded-drawn-chip border-2 border-pen-700 px-[14px] py-[7px] font-sans text-14 text-ink-1 transition-colors hover:border-pen-600 hover:bg-paper-high disabled:cursor-default disabled:opacity-40 disabled:hover:border-pen-700 disabled:hover:bg-transparent';
+
+/** One side of the board, paged on its own: the two columns rank different sets. */
+function Column({
+  side,
+  hand,
+}: { readonly side: LeaderboardSide; readonly hand: 'a' | 'b' }): JSX.Element {
+  const [page, setPage] = useState(1);
+  const { data, reading, failed, retry } = useBoard(side, page);
+
+  const pages = data === null || data.pageSize === 0 ? 0 : Math.ceil(data.total / data.pageSize);
+  const first = data === null ? 0 : (data.page - 1) * data.pageSize;
+
+  return (
+    <Panel hand={hand} span={6}>
+      {/* The band comes from the API, never a second copy of the ladder here:
+          this and the meter must call the same score the same thing. */}
+      <PanelHead title={TITLE[side]} kicker={data?.band} />
+
+      {reading && data === null ? (
+        <p className="mt-4 text-body text-ink-3">Reading the board…</p>
+      ) : failed && data === null ? (
+        <p className="mt-4 text-body text-ink-2">
+          {UNREADABLE}{' '}
+          <button
+            type="button"
+            className="underline underline-offset-2 hover:text-hand"
+            onClick={retry}
+          >
+            Try again
+          </button>
+        </p>
+      ) : data === null || data.rows.length === 0 ? (
+        <p className="mt-4 text-body text-ink-2">{EMPTY}</p>
+      ) : (
+        <ol className="m-0 mt-4 list-none p-0" style={{ opacity: reading ? 0.5 : 1 }}>
+          {data.rows.map((row, index) => (
+            <Rank key={row.host} place={first + index + 1} row={row} />
+          ))}
+        </ol>
+      )}
+
+      {pages > 1 && (
+        <nav className="mt-auto flex items-center gap-3 pt-5" aria-label={`${TITLE[side]} pages`}>
+          <button
+            type="button"
+            className={STEP}
+            disabled={page <= 1}
+            onClick={() => setPage(page - 1)}
+          >
+            ← Back
+          </button>
+          <span className="text-13 leading-[1.5] text-ink-3">
+            Page {page} of {pages}
+          </span>
+          <button
+            type="button"
+            className={STEP}
+            disabled={page >= pages}
+            onClick={() => setPage(page + 1)}
+          >
+            Next →
+          </button>
+        </nav>
+      )}
+    </Panel>
+  );
+}
+
+/**
+ * What the readings add up to: the sites that look least and most like every
+ * other AI-built site. One row per host, the latest reading of it.
+ */
+export function LeaderboardView(): JSX.Element {
+  const tool = toolCopy(LEADERBOARD_TOOL);
+
+  return (
+    <PanelGrid>
+      {/* The way back is the reading this board is of, not the browser's back
+          button: a visitor may have arrived here from a search result. */}
+      {/* An anchor, not the report's button: this is its own page and a visitor
+          may have arrived from a search result with nothing to go back to. The
+          chip is the report's, so the two read as one control. */}
+      <div className="col-span-6 lg:col-span-12">
+        <a
+          href={`${BASE}/${tool.slug}`}
+          className="inline-flex items-center gap-[9px] rounded-drawn-chip border-[1.6px] border-pen-700 bg-transparent px-4 py-[9px] font-sans text-15 font-medium text-ink-1 transition-colors hover:border-pen-600 hover:bg-paper-high"
+        >
+          <svg
+            viewBox="0 0 20 12"
+            className="h-[12px] w-[20px] fill-none stroke-current"
+            aria-hidden="true"
+            strokeWidth={1.8}
+            strokeLinecap="round"
+          >
+            <path d="M19 6.1c-6-.5-12.1-.7-18-.4M6 1.2C4.2 2.9 2.5 4.6.9 6.3c1.7 1.7 3.4 3.4 5.2 5" />
+          </svg>
+          Back to the reading
+        </a>
+      </div>
+      <Column side="best" hand="a" />
+      <Column side="worst" hand="b" />
+    </PanelGrid>
+  );
+}

--- a/apps/console/src/features/leaderboard/Rank.tsx
+++ b/apps/console/src/features/leaderboard/Rank.tsx
@@ -1,0 +1,23 @@
+import type { LeaderboardRow } from '@lumioguard/shared';
+
+/** One place on the board. The same row whether five are shown or fifty. */
+export function Rank({
+  place,
+  row,
+}: {
+  readonly place: number;
+  readonly row: LeaderboardRow;
+}): JSX.Element {
+  return (
+    <li className="flex items-baseline gap-3 border-b border-pen-900 py-[9px] last:border-b-0">
+      <span className="w-[24px] shrink-0 text-right font-hand text-16 tabular-nums text-ink-3">
+        {place}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-body leading-[1.3] text-ink-1">{row.host}</span>
+        <span className="mt-[1px] block text-caption text-ink-3">{row.tier}</span>
+      </span>
+      <span className="shrink-0 font-hand text-20 tabular-nums text-ink-1">{row.score}</span>
+    </li>
+  );
+}

--- a/apps/console/src/features/leaderboard/useBoard.ts
+++ b/apps/console/src/features/leaderboard/useBoard.ts
@@ -1,0 +1,42 @@
+import type { LeaderboardResponse, LeaderboardSide } from '@lumioguard/shared';
+import { useEffect, useState } from 'react';
+import { LeaderboardClient } from './LeaderboardClient.js';
+
+const client = new LeaderboardClient();
+
+export interface BoardState {
+  readonly data: LeaderboardResponse | null;
+  readonly reading: boolean;
+  /** A failure, which is not the same fact as an empty board. */
+  readonly failed: boolean;
+  readonly retry: () => void;
+}
+
+/** One side of the board, read and re-readable. Shared by the board and its preview. */
+export function useBoard(side: LeaderboardSide, page: number): BoardState {
+  const [data, setData] = useState<LeaderboardResponse | null>(null);
+  const [reading, setReading] = useState(true);
+  const [failed, setFailed] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+
+  // `attempt` is not read in here: it IS the trigger, and bumping it is what
+  // asks the board again after a failed load.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the extra dep is the point
+  useEffect(() => {
+    const abort = new AbortController();
+    setReading(true);
+    setFailed(false);
+    client.page(side, page, abort.signal).then((result) => {
+      if (abort.signal.aborted) return;
+      // Null is a FAILURE, not an empty board: the first is worth retrying and
+      // the second is the answer. Read as one, a dropped request said the site
+      // had never been scanned.
+      if (result === null) setFailed(true);
+      else setData(result);
+      setReading(false);
+    });
+    return () => abort.abort();
+  }, [side, page, attempt]);
+
+  return { data, reading, failed, retry: () => setAttempt(attempt + 1) };
+}

--- a/apps/console/src/features/report/ConsoleReport.tsx
+++ b/apps/console/src/features/report/ConsoleReport.tsx
@@ -128,16 +128,11 @@ export function ConsoleReport({
 
       {!isReading && landed.length > 0 && <FailedReadings readings={readings} />}
 
-      {/* Both are ABOUT the whole reading, so neither is drawn until the whole
-          reading is in. Ranking culprits across tools while a tool is still
-          reading shows an order that is about to change, and the render beside
-          it would arrive alone and then be shoved down. */}
-      {!isReading && landed.length > 0 && (
-        <>
-          <SiteShot address={address} />
-          <Culprits readings={readings} />
-        </>
-      )}
+      {/* Mounted from the first frame and kept mounted, so the render samples
+          up and the culprits rule while the needle hunts. Held back until the
+          last tool landed, both arrived after the wait they exist to fill. */}
+      <SiteShot address={address} resolving={isReading} />
+      <Culprits readings={readings} pending={isReading} />
 
       {landed.map((reading) => (
         <ReadingSection key={reading.tool.id} reading={reading} />

--- a/apps/console/src/features/report/Culprits.tsx
+++ b/apps/console/src/features/report/Culprits.tsx
@@ -3,6 +3,50 @@ import type { Reading } from '../scan/useReadings.js';
 
 const SHOWN = 6;
 
+/** One ruled line, drawn rather than a grey block. */
+function Rule({ className }: { readonly className: string }): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 200 6"
+      preserveAspectRatio="none"
+      className={`h-[6px] fill-none stroke-pen-700 ${className}`}
+      aria-hidden="true"
+      strokeLinecap="round"
+      strokeWidth={1.5}
+    >
+      <path vectorEffect="non-scaling-stroke" d="M2 3.4C52 2.2 102 4.2 152 3c16-.4 32 .6 46 .2" />
+    </svg>
+  );
+}
+
+/** Placeholder rows, keyed by identity: they are static and never reorder. */
+const RULES = Array.from({ length: SHOWN }, (_, row) => ({ id: `rule-${row}`, row }));
+
+/**
+ * The panel while the readings are still running. SHOWN rows, so the panel is
+ * the height it will be and nothing below it moves when the real list lands.
+ */
+function Ruling(): JSX.Element {
+  return (
+    <ol className="m-0 mt-4 list-none p-0" aria-hidden="true">
+      {RULES.map(({ id, row }) => (
+        <li key={id} className="border-b border-pen-900 py-[10px] last:border-b-0">
+          <span
+            className="ruling flex items-baseline gap-3"
+            style={{ animationDelay: `${row * 150}ms` }}
+          >
+            <Rule className="w-[30px] shrink-0" />
+            <span className="min-w-0 flex-1">
+              <Rule className={`block ${row % 2 === 0 ? 'w-full' : 'w-[86%]'}`} />
+              <Rule className={`mt-[17px] block ${row % 2 === 0 ? 'w-[48%]' : 'w-[57%]'}`} />
+            </span>
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
 /**
  * The worst of everything, across every reading.
  *
@@ -16,7 +60,17 @@ const SHOWN = 6;
  * to know which section below to look in, and because a bare list of six
  * problems reads as one engine's opinion rather than three.
  */
-export function Culprits({ readings }: { readonly readings: readonly Reading[] }): JSX.Element {
+export function Culprits({
+  readings,
+  pending,
+}: {
+  readonly readings: readonly Reading[];
+  /**
+   * True until every reading is in. The panel rules rather than ranking: a
+   * partial order across three engines is one that is about to change.
+   */
+  readonly pending: boolean;
+}): JSX.Element {
   const all = readings
     .flatMap((reading) =>
       (reading.outcome?.culprits ?? []).map((culprit) => ({
@@ -33,7 +87,9 @@ export function Culprits({ readings }: { readonly readings: readonly Reading[] }
     <Panel hand="b" span={5}>
       <PanelHead title="The culprits" mark={<MarkScored />} />
 
-      {top.length === 0 ? (
+      {pending ? (
+        <Ruling />
+      ) : top.length === 0 ? (
         <p className="mt-4 text-body text-ink-2">Nothing was charged by any reading.</p>
       ) : (
         <ol className="m-0 mt-4 list-none p-0">
@@ -62,7 +118,7 @@ export function Culprits({ readings }: { readonly readings: readonly Reading[] }
         </ol>
       )}
 
-      {all.length > top.length && (
+      {!pending && all.length > top.length && (
         <p className="mt-auto pt-5 text-13 leading-[1.5] text-ink-2">
           {all.length - top.length} more are listed under each reading below.
         </p>

--- a/apps/console/src/features/report/SiteShot.tsx
+++ b/apps/console/src/features/report/SiteShot.tsx
@@ -9,16 +9,26 @@ import { Panel, PanelHead, ResolvingShot } from '@lumioguard/ui';
  * Slopmeter's section it appeared or vanished depending on whether that one
  * tool had been selected.
  */
-export function SiteShot({ address }: { readonly address: string }): JSX.Element | null {
+export function SiteShot({
+  address,
+  resolving,
+}: {
+  readonly address: string;
+  /** True while any reading is still running: the render samples up as it waits. */
+  readonly resolving: boolean;
+}): JSX.Element | null {
   const src = mshotsUrl(address);
   if (src === null) return null;
 
   return (
     <Panel hand="d" span={7}>
       <PanelHead title="See it for yourself" />
-      {/* `resolving` is false because this is drawn only once every reading has
-          landed. The sampling animation exists to fill a wait that is over. */}
-      <ResolvingShot src={src} alt={`Render of ${address}`} address={address} resolving={false} />
+      <ResolvingShot
+        src={src}
+        alt={`Render of ${address}`}
+        address={address}
+        resolving={resolving}
+      />
     </Panel>
   );
 }

--- a/apps/console/src/features/scan/useConsoleRoute.ts
+++ b/apps/console/src/features/scan/useConsoleRoute.ts
@@ -13,6 +13,8 @@ export interface ConsoleRoute {
   readonly pinned: ToolCopy | null;
   /** The chooser scans nothing: it is the page that sends you to one that does. */
   readonly chooser: boolean;
+  /** The board scans nothing either: it ranks what has already been read. */
+  readonly board: boolean;
 }
 
 /** The ways the page changes it, each writing history and re-reading. */
@@ -49,6 +51,7 @@ export function useConsoleRoute(): ConsoleRoute & RouteControls {
     toolIds: route.toolIds,
     pinned: route.pinned,
     chooser: route.chooser,
+    board: route.board,
     open: useCallback((next: string) => go((params) => params.set(SITE, next), true), [go]),
     // No scroll: changing the selection re-reads in place, and yanking the page
     // to the top on a checkbox loses whatever the reader was looking at.
@@ -76,12 +79,15 @@ function read(): ConsoleRoute {
   // would quietly read something the heading never offered.
   const page = pageForPath(window.location.pathname);
   if (page.kind === 'tool') {
-    return { address, toolIds: [page.tool.id], pinned: page.tool, chooser: false };
+    return { address, toolIds: [page.tool.id], pinned: page.tool, chooser: false, board: false };
   }
 
   const chooser = page.kind === 'choose';
+  const board = page.kind === 'leaderboard';
   const raw = params.get(TOOLS_PARAM);
-  if (raw === null) return { address, toolIds: DEFAULT_TOOL_IDS, pinned: null, chooser };
+  if (raw === null) {
+    return { address, toolIds: DEFAULT_TOOL_IDS, pinned: null, chooser, board };
+  }
 
   const wanted = raw.split(',').map((id) => id.trim());
   const known = TOOLS.filter((tool) => wanted.includes(tool.id)).map((tool) => tool.id);
@@ -90,5 +96,6 @@ function read(): ConsoleRoute {
     toolIds: known.length === 0 ? DEFAULT_TOOL_IDS : known,
     pinned: null,
     chooser,
+    board,
   };
 }

--- a/apps/console/src/tools/catalogue.ts
+++ b/apps/console/src/tools/catalogue.ts
@@ -21,6 +21,8 @@ export interface ToolCopy {
   readonly slug: string;
   /** The question that page asks, standing in for the home page's own. */
   readonly headline: string;
+  /** What this reading looks for: the middle beat of how it works, on its own page. */
+  readonly checks: string;
   /** What a search result shows for that page. Under 160 characters. */
   readonly description: string;
 }
@@ -32,7 +34,8 @@ export const CATALOGUE: readonly ToolCopy[] = [
     label: 'AI slop',
     summary: 'See how much of the site feels templated.',
     slug: 'ai-slop-check',
-    headline: 'Does this site feel original or AI-generic?',
+    headline: 'Does this site feel original?',
+    checks: 'We check for signs that make a website look like every other AI website',
     description:
       'Score any public site for the defaults generated sites ship with: stock hero lines, bento grids, glow instead of shadow, and the vocabulary chatbots reach for.',
   },
@@ -42,6 +45,7 @@ export const CATALOGUE: readonly ToolCopy[] = [
     summary: 'See what your site exposes publicly.',
     slug: 'security-check',
     headline: 'What is this site exposing?',
+    checks: 'We check for surface-level security issues',
     description:
       'Read any public site for what it gives away: keys in the bundle, a database with no row-level security, source maps, and files served from the web root.',
   },
@@ -51,6 +55,7 @@ export const CATALOGUE: readonly ToolCopy[] = [
     summary: 'See what makes your site harder for search and AI to understand.',
     slug: 'seo-ai-visibility-check',
     headline: 'Can search engines and AI find this site?',
+    checks: 'We check for things that make it hard for Google and AI agents to read your website',
     description:
       'Read any public site the way a crawler does: a body that is empty without JavaScript, crawlers turned away, and nothing an answer could be lifted from.',
   },
@@ -66,6 +71,15 @@ export function toolCopy(id: string): ToolCopy {
 /** Every reading at once, which is a page rather than a reading of its own. */
 export const SCAN_SLUG = 'scan';
 
+/** What has been read, ranked. Also a page rather than a reading. */
+export const LEADERBOARD_SLUG = 'leaderboard';
+
+/**
+ * The board is the AI slop reading's own, so it sits under that reading's path
+ * rather than at the root. Derived: renaming that slug moves the board with it.
+ */
+export const LEADERBOARD_TOOL = 'slopmeter';
+
 /**
  * Which of the three documents a path is. The build reads it to know what to
  * prerender and the app to know what to run, and answered separately in each
@@ -74,6 +88,7 @@ export const SCAN_SLUG = 'scan';
 export type ConsolePage =
   | { readonly kind: 'tool'; readonly tool: ToolCopy }
   | { readonly kind: 'scan' }
+  | { readonly kind: 'leaderboard' }
   | { readonly kind: 'choose' };
 
 /** The last path segment, however the app is mounted and whether or not `.html`. */
@@ -87,5 +102,12 @@ export function pageForPath(pathname: string): ConsolePage {
   const slug = segment(pathname);
   const tool = CATALOGUE.find((entry) => entry.slug === slug);
   if (tool !== undefined) return { kind: 'tool', tool };
-  return slug === SCAN_SLUG ? { kind: 'scan' } : { kind: 'choose' };
+  if (slug === SCAN_SLUG) return { kind: 'scan' };
+  if (slug === LEADERBOARD_SLUG) return { kind: 'leaderboard' };
+  return { kind: 'choose' };
+}
+
+/** Where the board lives: under the reading it ranks. */
+export function leaderboardPath(): string {
+  return `/${toolCopy(LEADERBOARD_TOOL).slug}/${LEADERBOARD_SLUG}`;
 }

--- a/apps/console/src/tools/citecheck/WhyItMatters.tsx
+++ b/apps/console/src/tools/citecheck/WhyItMatters.tsx
@@ -1,0 +1,24 @@
+import { MarkLegible, Panel, PanelHead } from '@lumioguard/ui';
+
+/**
+ * Why the reading is worth taking, on the page that offers it. Two short
+ * paragraphs: what visibility buys, then what its absence costs.
+ */
+export function WhyItMatters(): JSX.Element {
+  return (
+    <Panel hand="c" span={12} className="mt-6">
+      <PanelHead title="Be Found Wherever People Search" mark={<MarkLegible />} />
+      <p className="mt-4 text-body leading-[1.6] text-ink-2">
+        SEO and AI visibility help people discover your website when they are looking for a product,
+        service, or answer. Clear, accessible content makes it easier for platforms like Google,
+        ChatGPT, Perplexity, and Gemini to understand what your site offers and surface it to the
+        right people.
+      </p>
+      <p className="mt-3 text-body leading-[1.6] text-ink-2">
+        If your site is difficult to crawl, poorly structured, or unclear about what it does, you
+        can miss those opportunities completely. Good visibility makes your website easier to find,
+        understand, and recommend wherever people are searching.
+      </p>
+    </Panel>
+  );
+}

--- a/apps/console/src/tools/leakpeek/CommonIssues.tsx
+++ b/apps/console/src/tools/leakpeek/CommonIssues.tsx
@@ -1,0 +1,31 @@
+import { MarkExposed, Panel, PanelHead } from '@lumioguard/ui';
+import { KNOWN_ISSUES, type KnownIssue } from './knownIssues.js';
+
+function Issue({ issue }: { readonly issue: KnownIssue }): JSX.Element {
+  return (
+    <li className="border-b border-pen-900 py-[15px] last:border-b-0 last:pb-0">
+      <span className="block text-body leading-[1.3] text-ink-1">{issue.title}</span>
+      {/* No width cap: the row is the measure. Capped at 92ch the second line
+          wrapped short of the frame and read as a column inside a panel. */}
+      <span className="mt-[6px] block text-caption leading-[1.6] text-ink-3">{issue.detail}</span>
+    </li>
+  );
+}
+
+/**
+ * The ten that come up most where developers audit AI-built apps and write down
+ * what they found. Read `knownIssues.ts` for where they came from, and for why
+ * this is not a list of what this tool checks.
+ */
+export function CommonIssues(): JSX.Element {
+  return (
+    <Panel hand="c" span={12} className="mt-6">
+      <PanelHead title="Common Security Failures in AI-Built Apps" mark={<MarkExposed />} />
+      <ol className="m-0 mt-4 list-none p-0">
+        {KNOWN_ISSUES.map((issue) => (
+          <Issue key={issue.title} issue={issue} />
+        ))}
+      </ol>
+    </Panel>
+  );
+}

--- a/apps/console/src/tools/leakpeek/knownIssues.ts
+++ b/apps/console/src/tools/leakpeek/knownIssues.ts
@@ -1,0 +1,78 @@
+/**
+ * What developers auditing AI-built apps report finding, over and over.
+ *
+ * ORDERED BY HOW MANY INDEPENDENT WRITE-UPS REPORT IT, not by judgement. Eight
+ * threads on r/vibecoding and r/SaaS where someone opened other people's
+ * shipped apps and listed what was wrong, and the tally across them:
+ *
+ *   5  RLS missing                5  secrets in the frontend
+ *   4  admin only in the UI       3  records fetched by id
+ *   3  writable account fields    3  no limit on costly endpoints
+ *   2  client sets the charge     2  .env or .git reachable
+ *   2  local storage trusted      2  tokens not verified
+ *
+ * Merged where the reports were one fault under several names: hidden buttons,
+ * client-side admin checks and an open /admin are all a missing server-side
+ * check. Source maps are absent because no thread raised them, only this tool.
+ *
+ * This is what goes wrong in general, NOT a list of what this tool checks. It
+ * reads three of them from outside; the rest need an account, a second account,
+ * or the server's own code.
+ */
+export interface KnownIssue {
+  readonly title: string;
+  readonly detail: string;
+}
+
+export const KNOWN_ISSUES: readonly KnownIssue[] = [
+  {
+    title: 'Row Level Security is missing',
+    detail:
+      'Your frontend can connect to the database, but the tables have no RLS rules. Anyone who finds the public client key may be able to read every row, and sometimes update or delete them too.',
+  },
+  {
+    title: 'Secrets end up in the frontend',
+    detail:
+      'API keys, payment keys or service-role tokens are added to client-side code. Once the app is deployed, those values can be extracted from the browser bundle and used outside your app.',
+  },
+  {
+    title: 'Admin access only exists in the UI',
+    detail:
+      'The app hides admin buttons from normal users, but the API itself does not check permissions. Someone can call the endpoint directly and bypass what the interface is hiding.',
+  },
+  {
+    title: 'Any record can be fetched by changing the ID',
+    detail:
+      "The app loads data using an ID from the URL or request without checking who owns it. Changing that ID can return another user's account, order, document or private data.",
+  },
+  {
+    title: 'Users can change protected account fields',
+    detail:
+      'Fields such as role, plan, credits or balance can be updated by the user. Someone can change their own account to admin, paid or unlimited without going through the intended flow.',
+  },
+  {
+    title: 'Expensive endpoints have no limits',
+    detail:
+      'AI calls, emails, SMS, image generation or other paid APIs can be called without rate limits. A script can burn through your credits or generate a large bill very quickly.',
+  },
+  {
+    title: 'The client decides how much to charge',
+    detail:
+      'The frontend sends the payment amount and the server trusts it. A user can change the request before sending it, or fake payment events if webhook signatures are not verified.',
+  },
+  {
+    title: '.env or .git files are publicly accessible',
+    detail:
+      'Deployment or server configuration exposes files that should never be reachable from the web. A simple request can reveal database URLs, API keys and other credentials.',
+  },
+  {
+    title: 'The app trusts local storage',
+    detail:
+      'Roles, user IDs or account status are stored in the browser and treated as trusted values. Users can edit local storage themselves, so it should never decide what they are allowed to do.',
+  },
+  {
+    title: 'Login tokens are not properly verified',
+    detail:
+      'The app accepts session tokens without fully checking their signature, expiry or issuer. In the worst case, someone can create their own token and pretend to be any user.',
+  },
+];

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -6,7 +6,7 @@ import { type ProxyOptions, type UserConfig, defineConfig } from 'vite';
 // part of the typechecked app.
 import { HOST, apiPorts, appPort } from '../../scripts/ports.mjs';
 import { seo } from './build/seo.js';
-import { CATALOGUE } from './src/tools/catalogue.js';
+import { CATALOGUE, SCAN_SLUG, leaderboardPath } from './src/tools/catalogue.js';
 
 const TOOL_PAGES = CATALOGUE.map((tool) => tool.slug);
 
@@ -42,7 +42,10 @@ export default defineConfig({
     rollupOptions: {
       input: {
         index: source('index.html'),
-        scan: source('scan.html'),
+        [SCAN_SLUG]: source(`${SCAN_SLUG}.html`),
+        // Nested, so it is emitted at ai-slop-check/leaderboard.html and served
+        // at that path with a 200, the way every other document here is.
+        leaderboard: source(`.${leaderboardPath()}.html`),
         ...Object.fromEntries(TOOL_PAGES.map((slug) => [slug, source(`${slug}.html`)])),
       },
     },

--- a/packages/shared/src/contracts/leaderboard.ts
+++ b/packages/shared/src/contracts/leaderboard.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/** Ranked either way, from the same collapsed set of hosts. */
+export const leaderboardSideSchema = z.enum(['best', 'worst']);
+export type LeaderboardSide = z.infer<typeof leaderboardSideSchema>;
+
+/**
+ * One host, as the board ranks it.
+ *
+ * No site key and no findings: a key resolves to a whole reading, and this list
+ * is public. What a site was charged for stays in that site's own report.
+ */
+export const leaderboardRowSchema = z.object({
+  host: z.string().min(1),
+  score: z.number().int().min(0).max(100),
+  tier: z.string(),
+  readAt: z.string(),
+});
+export type LeaderboardRow = z.infer<typeof leaderboardRowSchema>;
+
+export const leaderboardResponseSchema = z.object({
+  side: leaderboardSideSchema,
+  /**
+   * The band this column IS, in the tool's own words, and the column's title.
+   * Sent rather than looked up here: the ladder belongs to the engine, and a
+   * second copy of it in the console is one that can disagree.
+   */
+  band: z.string().min(1),
+  page: z.number().int().positive(),
+  pageSize: z.number().int().nonnegative(),
+  /** Hosts on this side of the board, already capped by the API. */
+  total: z.number().int().nonnegative(),
+  rows: z.array(leaderboardRowSchema),
+});
+export type LeaderboardResponse = z.infer<typeof leaderboardResponseSchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -144,3 +144,11 @@ export {
 } from './domain/readingTier.js';
 // `TrackSegment` is already re-exported by tier.js; one name, one export.
 export { bandOf, trackOf, type ScoreBand } from './domain/band.js';
+export {
+  leaderboardResponseSchema,
+  leaderboardRowSchema,
+  leaderboardSideSchema,
+  type LeaderboardResponse,
+  type LeaderboardRow,
+  type LeaderboardSide,
+} from './contracts/leaderboard.js';

--- a/packages/ui/src/components/HowItWorks.tsx
+++ b/packages/ui/src/components/HowItWorks.tsx
@@ -104,7 +104,6 @@ function ArtScore(): JSX.Element {
   );
 }
 
-/** Plain, and in the page's own words. */
 /** The art is shared; the words are each tool's own. */
 export interface HowItWorksLabels {
   readonly paste: string;

--- a/tools/slopmeter/api/src/container.ts
+++ b/tools/slopmeter/api/src/container.ts
@@ -8,6 +8,7 @@ import {
 import { ScanResultMapper } from './mappers/ScanResultMapper.js';
 import { SiteReportMapper } from './mappers/SiteReportMapper.js';
 import { CrawlService } from './services/CrawlService.js';
+import { LeaderboardReader } from './services/LeaderboardReader.js';
 import { PageFetcher } from './services/PageFetcher.js';
 import { ScanService } from './services/ScanService.js';
 import { MShotsScreenshotProvider } from './services/ScreenshotProvider.js';
@@ -17,6 +18,7 @@ export interface Container {
   readonly scanService: ScanService;
   readonly crawlService: CrawlService;
   readonly recorder: ReadingRecorder;
+  readonly leaderboard: LeaderboardReader;
   readonly registry: ReturnType<typeof createDefaultRegistry>;
 }
 
@@ -42,6 +44,8 @@ export function getContainer(): Container {
     // Stateless and env-free: the endpoint and the signing key arrive with the
     // request, so they are passed to `record` rather than held here.
     recorder: new ReadingRecorder(),
+    // Env-free for the same reason: the address arrives with the request.
+    leaderboard: new LeaderboardReader(),
     scanService: new ScanService({
       resolver,
       fetcher,

--- a/tools/slopmeter/api/src/index.ts
+++ b/tools/slopmeter/api/src/index.ts
@@ -28,9 +28,18 @@ const app = new Hono<Bindings>();
 app.use('*', async (context, next) => corsFor(context.env.ALLOWED_ORIGINS)(context, next));
 
 app.use('*', standardHeaders());
+
+/**
+ * Paths that must not spend the SCAN budget. A board is a read of rows already
+ * taken, and the AI slop page asks for two of them on load: metered here, a
+ * visitor who opened that page twice could no longer scan anything. The board's
+ * own limit belongs upstream, with the data.
+ */
+const UNMETERED = new Set(['/api/health', '/api/leaderboard']);
+
 app.use('/api/*', async (context, next) => {
   if (
-    context.req.path !== '/api/health' &&
+    !UNMETERED.has(context.req.path) &&
     !(await allowedByRateLimit(context.env.SCAN_RATE_LIMITER, context.req.raw))
   ) {
     return context.json(
@@ -68,6 +77,24 @@ const analyze = (input: AnalyzeRequest): unknown =>
 
 /** Liveness only. */
 app.get('/api/health', (context) => context.json({ status: 'ok' }));
+
+/**
+ * The public board. FAILS CLOSED: with no LumioGuard address configured there
+ * is no board, never a fork reading somebody else's.
+ */
+app.get('/api/leaderboard', async (context) => {
+  const base = context.env.LUMIOGUARD_API_BASE_URL?.replace(/\/$/, '');
+  if (!base) return context.json({ error: 'No leaderboard here' }, 404);
+
+  const side = context.req.query('side') === 'worst' ? 'worst' : 'best';
+  const asked = Number(context.req.query('page') ?? '1');
+  const page = Number.isFinite(asked) ? Math.max(1, Math.floor(asked)) : 1;
+
+  const board = await getContainer().leaderboard.read(base, side, page);
+  // Generic: the upstream's reasons are not this Worker's to relay.
+  if (board === null) return context.json({ error: 'Leaderboard unavailable' }, 502);
+  return context.json(board);
+});
 
 app.post('/api/scan', endpoint(scanRequestSchema, jsonBody, scanPage));
 

--- a/tools/slopmeter/api/src/services/LeaderboardReader.ts
+++ b/tools/slopmeter/api/src/services/LeaderboardReader.ts
@@ -1,0 +1,96 @@
+/** A board is a few kilobytes; the console should not hang on a slow API. */
+const TIMEOUT_MS = 5000;
+
+/** Ranked either way, from the same collapsed set. */
+export type LeaderboardSide = 'best' | 'worst';
+
+/** One host, as the board ranks it. No site key: this is public. */
+export interface LeaderboardRow {
+  readonly host: string;
+  readonly score: number;
+  readonly tier: string;
+  readonly readAt: string;
+}
+
+export interface LeaderboardPage {
+  readonly side: LeaderboardSide;
+  /** The band this column is, in the tool's own words. */
+  readonly band: string;
+  readonly page: number;
+  readonly pageSize: number;
+  readonly total: number;
+  readonly rows: readonly LeaderboardRow[];
+}
+
+/** The slice of `fetch` this needs, and no more. */
+export type BoardTransport = (
+  url: string,
+  init: { readonly signal?: AbortSignal },
+) => Promise<{ readonly ok: boolean; readonly json: () => Promise<unknown> }>;
+
+/**
+ * The board, read from LumioGuard.
+ *
+ * Proxied through this Worker rather than fetched by the browser: the console
+ * is open source and carries no LumioGuard address, and going direct would bake
+ * one into the bundle and need a CORS entry on an API this repo does not own.
+ */
+export class LeaderboardReader {
+  private readonly send: BoardTransport;
+
+  /**
+   * A WRAPPER, not `globalThis.fetch` itself: Workers' fetch throws "Illegal
+   * invocation" once detached from the global, and a field detaches it.
+   */
+  public constructor(send: BoardTransport = (url, init) => fetch(url, init)) {
+    this.send = send;
+  }
+
+  /**
+   * The page, or null when it could not be read. Never throws: a board that is
+   * unavailable is a panel that says so, not a failed request to the console.
+   */
+  public async read(
+    base: string,
+    side: LeaderboardSide,
+    page: number,
+  ): Promise<LeaderboardPage | null> {
+    const url = `${base}/api/external/slopmeter/leaderboard?side=${side}&page=${page}`;
+    try {
+      const response = await this.send(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+      if (!response.ok) return null;
+      return asPage(await response.json(), side, page);
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Narrowed, not trusted: this crosses a network before it reaches a screen. */
+function asPage(body: unknown, side: LeaderboardSide, page: number): LeaderboardPage | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const raw = body as Record<string, unknown>;
+  if (!Array.isArray(raw.rows) || typeof raw.band !== 'string') return null;
+
+  const rows: LeaderboardRow[] = [];
+  for (const item of raw.rows) {
+    if (typeof item !== 'object' || item === null) continue;
+    const row = item as Record<string, unknown>;
+    if (typeof row.host !== 'string' || typeof row.score !== 'number') continue;
+    rows.push({
+      host: row.host,
+      score: row.score,
+      tier: typeof row.tier === 'string' ? row.tier : '',
+      readAt: typeof row.readAt === 'string' ? row.readAt : '',
+    });
+  }
+
+  return {
+    side,
+    band: typeof raw.band === 'string' ? raw.band : '',
+    page,
+    pageSize: typeof raw.pageSize === 'number' ? raw.pageSize : rows.length,
+    total: typeof raw.total === 'number' ? raw.total : rows.length,
+    rows,
+  };
+}


### PR DESCRIPTION
## What this changes, and why

Each reading page now carries something under the address field, and two
regressions are undone.

**The loading effects came back.** `06b4223` had switched both off when the
console was consolidated over three tools: `SiteShot` was passed a hard-coded
`resolving={false}`, and both it and `Culprits` were withheld until every
reading landed, so the animations existed to fill a wait that was already over.
The `@keyframes ruling` for the culprits skeleton was still in `styles.css`,
unused since that commit. Both panels now mount on the first frame, and the
panel rules rather than ranking while a tool is still reading, which answers the
objection the old comment raised.

**A leaderboard for the AI slop reading**, at `/ai-slop-check/leaderboard`, with
a five-a-side preview under the address field. No new table: `external_readings`
already holds host, score, tier and read_at. Two properties of it shape the
query, and both are load-bearing:

- it stores one row per READING, so the board collapses with `DISTINCT ON (host)`
- the band filter sits OUTSIDE that collapse, so a site read badly once and well
  since is judged on the reading it has now

A column IS a band, taken from the tool's own `tiers` ladder. Ranked by halves
first, a board of fourteen put a site scoring 92 among the most templated purely
for falling below the median.

The console reads it through Slopmeter's Worker rather than from the browser:
this bundle is open source and carries no LumioGuard address, and going direct
would bake one in and need a CORS entry on an API this repo does not own. The
board is exempt from the SCAN rate limiter, because two board requests per page
load were spending a visitor's scan budget.

**Two panels of copy**, and per-reading wording for the middle "how it works"
beat, which now lives on each tool in the catalogue.

## Checks

```
pnpm typecheck && pnpm lint && pnpm test && pnpm build
```

- [x] All four pass. Lint is clean, not merely quieter.

## If you touched a detection engine

Not touched. No rule, no scoring change.

## If you touched the wire

`leaderboardResponseSchema` is new in `shared`. It carries host, score, tier and
the band name only.

- [x] No rule id, category or catalogue entry crosses it.
- [x] A site key never reaches the board; a test asserts the response contains
      neither a site key nor findings.

## If you touched Leakpeek's probes

Not touched. The security panel is copy, and the four items this tool can prove
are the four it already probed.

## Anything else

- [x] No new hard-coded LumioGuard address. The Worker fails closed: with no
      `LUMIOGUARD_API_BASE_URL` there is no board, never a fork reading someone
      else's.

Depends on `GET /api/external/:toolId/leaderboard` in the stack-guard repo.
Until that ships the board renders "The board could not be read".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiMGHCDBKFgRLAxW1GL3e8