### PR TITLE
refactor(shared): rename the outer score bands to crafted and slop

### DIFF
--- a/apps/console/src/tools/slopmeter/theme.ts
+++ b/apps/console/src/tools/slopmeter/theme.ts
@@ -14,10 +14,10 @@ import type { VerdictScale } from '@lumioguard/ui';
  * tool's vocabulary, so the mapping lives here.
  */
 const TIER_INK: Record<Tier, string> = {
-  'Hand-Crafted': band.calm,
+  Crafted: band.calm,
   'Lightly Templated': band.notice,
   'Heavily Templated': band.warn,
-  'Pure Slop': band.alarm,
+  Slop: band.alarm,
 };
 
 export function tierInk(tier: Tier): string {

--- a/packages/shared/src/domain/__tests__/tier.test.ts
+++ b/packages/shared/src/domain/__tests__/tier.test.ts
@@ -11,7 +11,7 @@ describe('the tier ladder', () => {
 
   // Higher is better: the ladder ends at the top of the scale, worst band first.
   it('runs from the worst band to the best, and ends at the top of the scale', () => {
-    expect(TIER_BANDS[0]?.tier).toBe(Tier.PureSlop);
+    expect(TIER_BANDS[0]?.tier).toBe(Tier.Slop);
     expect(TIER_BANDS.at(-1)?.to).toBe(SCORE_MAX);
   });
 
@@ -26,10 +26,10 @@ describe('the tier ladder', () => {
 
   it('holds the thresholds the scoring is tuned against', () => {
     expect(TIER_BANDS.map((band) => [band.tier, band.from, band.to])).toEqual([
-      [Tier.PureSlop, 0, 40],
+      [Tier.Slop, 0, 40],
       [Tier.HeavilyTemplated, 41, 60],
       [Tier.LightlyTemplated, 61, 80],
-      [Tier.HandCrafted, 81, 100],
+      [Tier.Crafted, 81, 100],
     ]);
   });
 });

--- a/packages/shared/src/domain/tier.ts
+++ b/packages/shared/src/domain/tier.ts
@@ -2,10 +2,10 @@ import { BAND_EDGES, type ScoreBand, type TrackSegment, trackOf } from './band.j
 
 /** Band names describe the OUTPUT, never the author. */
 export const Tier = {
-  HandCrafted: 'Hand-Crafted',
+  Crafted: 'Crafted',
   LightlyTemplated: 'Lightly Templated',
   HeavilyTemplated: 'Heavily Templated',
-  PureSlop: 'Pure Slop',
+  Slop: 'Slop',
 } as const;
 
 export type Tier = (typeof Tier)[keyof typeof Tier];
@@ -20,7 +20,7 @@ export interface TierBand extends ScoreBand {
 /** Ordered low to high; the first band whose ceiling is not exceeded wins. */
 export const TIER_BANDS: readonly TierBand[] = Object.freeze([
   {
-    tier: Tier.PureSlop,
+    tier: Tier.Slop,
     ...BAND_EDGES[0],
     description: 'Stock everything. The template is still showing.',
   },
@@ -35,7 +35,7 @@ export const TIER_BANDS: readonly TierBand[] = Object.freeze([
     description: 'Mostly deliberate, leaning on a few defaults the crowd also uses.',
   },
   {
-    tier: Tier.HandCrafted,
+    tier: Tier.Crafted,
     ...BAND_EDGES[3],
     description: 'Almost nothing here comes out of a box.',
   },

--- a/packages/ui/src/components/verdict/Band.tsx
+++ b/packages/ui/src/components/verdict/Band.tsx
@@ -131,8 +131,8 @@ export function Band({
 
           The end stations are anchored to the ends of the track rather than
           centred on their zones, exactly as the scale above them is. A name is
-          wider than a fifth of a narrow track: centred, `Hand-Crafted` hung 9px
-          off the left end of the instrument it labels once the meter gave up a
+          wider than a fifth of a narrow track: centred, an end name hung 9px off
+          the left end of the instrument it labels once the meter gave up a
           column to the figure at 768px. Anchored, no width can put a station
           past the track, and the outer names line up with the 0 and the 100
           they stand over. */}

--- a/tools/slopmeter/README.md
+++ b/tools/slopmeter/README.md
@@ -28,10 +28,10 @@ suite and the app it hands off to.
 
 | Tier | Score | Meaning |
 |---|---|---|
-| Hand-Crafted | 81–100 | Somebody made decisions here |
+| Crafted | 81–100 | Somebody made decisions here |
 | Lightly Templated | 61–80 | Mostly deliberate, leaning on a few defaults |
 | Heavily Templated | 41–60 | The template is doing most of the talking |
-| Pure Slop | 0–40 | Stock everything |
+| Slop | 0–40 | Stock everything |
 
 ## What it judges, and what it refuses to
 

--- a/tools/slopmeter/api/src/__tests__/reading-recorder.test.ts
+++ b/tools/slopmeter/api/src/__tests__/reading-recorder.test.ts
@@ -29,7 +29,7 @@ function report(overrides: Partial<CrawlResponse> = {}): CrawlResponse {
     requestedMaxPages: 15,
     site: {
       score: 61,
-      tier: 'Pure Slop',
+      tier: 'Slop',
       tierDescription: 'Stock everything. The template is still showing.',
       headline: 'placeholder Latin still in the copy',
       method: 'max(homepage, median)',
@@ -138,7 +138,7 @@ describe('the recorded reading', () => {
     expect(body.host).toBe('example.com');
     expect(body.entryUrl).toBe('https://www.example.com/pricing');
     expect(body.score).toBe(61);
-    expect(body.tier).toBe('Pure Slop');
+    expect(body.tier).toBe('Slop');
   });
 
   it('sends the heaviest tells first and no more than ten', async () => {

--- a/tools/slopmeter/api/src/__tests__/wire-boundary.test.ts
+++ b/tools/slopmeter/api/src/__tests__/wire-boundary.test.ts
@@ -49,11 +49,11 @@ describe('the wire never carries rule identity', () => {
       provenance: Array<{ label: string }>;
     };
 
-    // Higher is better, so a Pure Slop page scores LOW. The penalty total is
+    // Higher is better, so a Slop page scores LOW. The penalty total is
     // unchanged: it is still what the rules charged, and only the score it is
     // subtracted from knows about the direction.
     expect(response.score).toBeLessThanOrEqual(40);
-    expect(response.tier).toBe('Pure Slop');
+    expect(response.tier).toBe('Slop');
     expect(response.breakdown.penalties).toBeGreaterThan(0);
 
     // Label, weight and evidence are the whole visible report; losing any of

--- a/tools/slopmeter/api/src/services/CrawlService.ts
+++ b/tools/slopmeter/api/src/services/CrawlService.ts
@@ -34,11 +34,8 @@ export class CrawlService {
      *
      * The crawler collects a page it cannot load into `errors` rather than
      * throwing, which is right when fourteen of fifteen pages loaded. When none
-     * did, the score is computed over no evidence and comes back 0,
-     * "Hand-Crafted: almost nothing here comes out of a box", about a site
-     * nothing was able to read. Worse in the console than alone: 0 is the best
-     * possible score, so a site behind a bot challenge would set a consolidated
-     * verdict of Clean while every other reading failed.
+     * did, the score is computed over no evidence, and a site behind a bot
+     * challenge is published as a reading rather than as the failure it is.
      */
     if (report.pagesScanned === 0) {
       // Says what happened, not why. A status the site did return is worth

--- a/tools/slopmeter/core/src/__tests__/analyzer.test.ts
+++ b/tools/slopmeter/core/src/__tests__/analyzer.test.ts
@@ -84,7 +84,7 @@ describe('leftovers', () => {
     expect(ids.has('leftover.lorem')).toBe(true);
     expect(ids.has('leftover.assistant-phrases')).toBe(true);
     expect(ids.has('leftover.your-company')).toBe(true);
-    expect(result.tier).toBe('Pure Slop');
+    expect(result.tier).toBe('Slop');
   });
 
   it('does not read ordinary English as a placeholder brand', () => {

--- a/tools/slopmeter/core/src/scoring/TierResolver.ts
+++ b/tools/slopmeter/core/src/scoring/TierResolver.ts
@@ -11,7 +11,7 @@ export class TierResolver {
     for (const band of this.bands) {
       if (score <= band.to) return band.tier;
     }
-    return Tier.PureSlop;
+    return Tier.Slop;
   }
 
   public describe(score: number): string {


### PR DESCRIPTION
`Hand-Crafted` becomes `Crafted` and `Pure Slop` becomes `Slop`. The middle two
bands are unchanged and no score moves: this is vocabulary, not scoring.

## This cannot ship alone

The tier STRING is what the leaderboard filters on and what `tierRank` looks up
in the tool's ladder, and stack-guard validates it at ingest. Renamed here only,
every reading this Worker sends is refused and silently not recorded, because
recording fails closed.

The other half is prepared in stack-guard: the registry `tiers` entry, its
tests, and migration `0099_slopmeter_band_names.sql`, which rewrites the stored
rows. **Deploy them together.**

## Also in here

`CrawlService`'s comment argued from 0 being the best possible score. Migration
0098 flipped every external score to higher-is-better and the comment never
moved, so it described the opposite of what the code does. Corrected while
renaming, since the rename had to touch that line anyway.

## Verified

`pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green here;
`@lumioguard/shared` 168/168 green in stack-guard with its half applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiMGHCDBKFgRLAxW1GL3e8