### PR TITLE
feat(console): read a leaderboard site in place, as an example does

### DIFF
--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -43,8 +43,8 @@ function Masthead(): JSX.Element {
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 /** What sits under the address field, which is the pinned reading's business. */
-function belowAsk(pinned: string | undefined): ReactNode {
-  if (pinned === LEADERBOARD_TOOL) return <LeaderboardPreview />;
+function belowAsk(pinned: string | undefined, onScan: (address: string) => void): ReactNode {
+  if (pinned === LEADERBOARD_TOOL) return <LeaderboardPreview onScan={onScan} />;
   if (pinned === 'leakpeek') return <CommonIssues />;
   if (pinned === 'citecheck') return <WhyItMatters />;
   return undefined;
@@ -206,7 +206,7 @@ export function App(): JSX.Element {
           pinned={pinned}
           // Each reading's own panel under the ask: the board is Slopmeter's,
           // the common issues are Leakpeek's, and the third has neither.
-          below={belowAsk(pinned?.id)}
+          below={belowAsk(pinned?.id, open)}
         />
       ) : (
         // No picker here. What to read is asked once, before the reading; on the

--- a/apps/console/src/features/leaderboard/BoardBody.tsx
+++ b/apps/console/src/features/leaderboard/BoardBody.tsx
@@ -12,10 +12,13 @@ const LINE = 'mt-4 text-body';
 export function BoardBody({
   board,
   limit,
+  onOpen,
 }: {
   readonly board: BoardState;
   /** The preview shows the head of the band; the board shows the page. */
   readonly limit?: number;
+  /** Given, a row reads its site in place rather than loading the page. */
+  readonly onOpen?: (host: string) => void;
 }): JSX.Element {
   const { data, reading, failed, retry } = board;
 
@@ -52,6 +55,7 @@ export function BoardBody({
           place={first + index + 1}
           row={row}
           href={readingHref(row.host)}
+          onOpen={onOpen}
         />
       ))}
     </div>

--- a/apps/console/src/features/leaderboard/LeaderboardPreview.tsx
+++ b/apps/console/src/features/leaderboard/LeaderboardPreview.tsx
@@ -18,10 +18,12 @@ const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 function Side({
   side,
   board,
+  onOpen,
   divided = false,
 }: {
   readonly side: LeaderboardSide;
   readonly board: BoardState;
+  readonly onOpen: (host: string) => void;
   readonly divided?: boolean;
 }): JSX.Element {
   const rule = divided
@@ -31,7 +33,7 @@ function Side({
   return (
     <div className={`min-w-0 ${rule}`}>
       <p className="m-0 font-hand text-16 text-ink-3">{board.data?.band ?? WAITING[side]}</p>
-      <BoardBody board={board} limit={SHOWN} />
+      <BoardBody board={board} limit={SHOWN} onOpen={onOpen} />
     </div>
   );
 }
@@ -46,7 +48,9 @@ function empty(board: BoardState): boolean {
  * shows nothing rather than an apology above the fold, but a board that could
  * not be READ says so and offers the read again.
  */
-export function LeaderboardPreview(): JSX.Element | null {
+export function LeaderboardPreview({
+  onScan,
+}: { readonly onScan: (address: string) => void }): JSX.Element | null {
   const best = useBoard('best', 1);
   const worst = useBoard('worst', 1);
 
@@ -91,8 +95,8 @@ export function LeaderboardPreview(): JSX.Element | null {
         </p>
       ) : (
         <div className="mt-5 grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-0">
-          <Side side="best" board={best} />
-          <Side side="worst" board={worst} divided />
+          <Side side="best" board={best} onOpen={onScan} />
+          <Side side="worst" board={worst} onOpen={onScan} divided />
         </div>
       )}
     </Panel>

--- a/apps/console/src/features/leaderboard/LedgerRow.tsx
+++ b/apps/console/src/features/leaderboard/LedgerRow.tsx
@@ -1,28 +1,32 @@
 import type { LeaderboardRow } from '@lumioguard/shared';
 import { VERDICT_SCALE } from '../../tools/slopmeter/theme.js';
 
-/**
- * One line of the ledger.
- *
- * Rank sits in a ruled margin rather than floating at the left, which is what
- * stops a run of these reading as a checklist. No band on the line: the panel
- * it sits in is that band, so printing it per row said the same word eleven
- * times. The score keeps the band's ink through `inkFor`, which takes a plain
- * string and falls back, because the wire carries a tier this surface does not
- * own the vocabulary for.
- */
 export function LedgerRow({
   place,
   row,
   href,
+  onOpen,
 }: {
   readonly place: number;
   readonly row: LeaderboardRow;
   readonly href: string;
+  /** Given, a plain click reads the site here instead of loading the page. */
+  readonly onOpen?: (host: string) => void;
 }): JSX.Element {
   return (
     <a
       href={href}
+      // A link, not a button, even where it reads in place: middle-click, the
+      // context menu and every modified click stay real navigation.
+      onClick={
+        onOpen === undefined
+          ? undefined
+          : (event) => {
+              if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+              event.preventDefault();
+              onOpen(row.host);
+            }
+      }
       className="grid grid-cols-[34px_minmax(0,1fr)_auto] items-stretch gap-x-4 border-t border-pen-900 px-1 transition-colors first:border-t-0 hover:bg-paper-high focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-pen-300"
     >
       <span className="flex items-center justify-end border-r border-pen-800 py-[10px] pr-3 font-hand text-15 text-ink-4">


### PR DESCRIPTION
A row in the leaderboard preview reloaded the page. An example chip beside it
reads the site in place. Same gesture, two behaviours.

A row now runs the app's own scan handler, so clicking `figma.com` in the board
does exactly what clicking the `figma.com` chip does.

It stays an `<a href>` rather than becoming a button: middle-click, the context
menu and every modified click remain real navigation. Only an unmodified left
click is intercepted.

Rows on the full board page keep navigating, because there is no address field
there to read into. They land on `?site=`, which starts the reading on arrival.

## Verified

Measured in the live DOM: a `window` marker set before the click survives it,
so no document was replaced, and the reading starts under a pushed
`?site=<host>`. Gate green: typecheck 12/12, lint 313 files, tests 12/12,
build 4/4.

Based on #14, which must merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiMGHCDBKFgRLAxW1GL3e8