### PR TITLE
fix(shared): name the top score band handmade

### DIFF
--- a/apps/console/src/tools/slopmeter/theme.ts
+++ b/apps/console/src/tools/slopmeter/theme.ts
@@ -14,7 +14,7 @@ import type { VerdictScale } from '@lumioguard/ui';
  * tool's vocabulary, so the mapping lives here.
  */
 const TIER_INK: Record<Tier, string> = {
-  Crafted: band.calm,
+  Handmade: band.calm,
   'Lightly Templated': band.notice,
   'Heavily Templated': band.warn,
   Slop: band.alarm,

--- a/packages/shared/src/domain/__tests__/tier.test.ts
+++ b/packages/shared/src/domain/__tests__/tier.test.ts
@@ -29,7 +29,7 @@ describe('the tier ladder', () => {
       [Tier.Slop, 0, 40],
       [Tier.HeavilyTemplated, 41, 60],
       [Tier.LightlyTemplated, 61, 80],
-      [Tier.Crafted, 81, 100],
+      [Tier.Handmade, 81, 100],
     ]);
   });
 });

--- a/packages/shared/src/domain/tier.ts
+++ b/packages/shared/src/domain/tier.ts
@@ -2,7 +2,7 @@ import { BAND_EDGES, type ScoreBand, type TrackSegment, trackOf } from './band.j
 
 /** Band names describe the OUTPUT, never the author. */
 export const Tier = {
-  Crafted: 'Crafted',
+  Handmade: 'Handmade',
   LightlyTemplated: 'Lightly Templated',
   HeavilyTemplated: 'Heavily Templated',
   Slop: 'Slop',
@@ -35,7 +35,7 @@ export const TIER_BANDS: readonly TierBand[] = Object.freeze([
     description: 'Mostly deliberate, leaning on a few defaults the crowd also uses.',
   },
   {
-    tier: Tier.Crafted,
+    tier: Tier.Handmade,
     ...BAND_EDGES[3],
     description: 'Almost nothing here comes out of a box.',
   },

--- a/tools/slopmeter/README.md
+++ b/tools/slopmeter/README.md
@@ -28,7 +28,7 @@ suite and the app it hands off to.
 
 | Tier | Score | Meaning |
 |---|---|---|
-| Crafted | 81–100 | Somebody made decisions here |
+| Handmade | 81–100 | Somebody made decisions here |
 | Lightly Templated | 61–80 | Mostly deliberate, leaning on a few defaults |
 | Heavily Templated | 41–60 | The template is doing most of the talking |
 | Slop | 0–40 | Stock everything |


### PR DESCRIPTION
The top band becomes `Handmade`. `Slop` is unchanged, as are the middle two.

Nothing had shipped yet: #14 renamed the ends but was never deployed, so this
lands before any reading is written under the previous word and no extra
migration is needed.

The stack-guard half moves with it: the registry `tiers` entry, its tests, and
migration `0099_slopmeter_band_names.sql`, which now writes `Handmade`. Deploy
them together, or the ingest refuses every reading and records nothing.

## Verified

typecheck 12/12, lint 313 files, tests 12/12, build 4/4 here.
`@lumioguard/shared` 168/168 in stack-guard with its half applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiMGHCDBKFgRLAxW1GL3e8