### PR TITLE
feat(console): set one spacing interval around the ask, and reword two lines

### DIFF
--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -106,7 +106,7 @@ function ReadingLink({
  */
 function ChooseView(): JSX.Element {
   return (
-    <PanelGrid centred>
+    <PanelGrid fills>
       <Panel hand="a" span={12}>
         <h1 className={H1}>
           <SiteQuestion />
@@ -142,7 +142,7 @@ function AskView({
   readonly below?: ReactNode;
 }): JSX.Element {
   return (
-    <PanelGrid centred>
+    <PanelGrid fills>
       <Panel hand="a" span={12}>
         <div className="grid gap-x-[46px] lg:grid-cols-[minmax(0,7fr)_minmax(0,4fr)]">
           <div className="flex flex-col lg:self-center">

--- a/apps/console/src/features/leaderboard/LeaderboardPreview.tsx
+++ b/apps/console/src/features/leaderboard/LeaderboardPreview.tsx
@@ -1,5 +1,5 @@
 import type { LeaderboardSide } from '@lumioguard/shared';
-import { MarkTemplate, Panel, PanelHead } from '@lumioguard/ui';
+import { GAP_BELOW_ASK, MarkTemplate, Panel, PanelHead } from '@lumioguard/ui';
 import { leaderboardPath } from '../../tools/catalogue.js';
 import { BoardBody } from './BoardBody.js';
 import { WAITING } from './board.js';
@@ -61,7 +61,7 @@ export function LeaderboardPreview({
   const lost = best.data === null && worst.data === null && best.failed && worst.failed;
 
   return (
-    <Panel hand="c" span={12} className="mt-6">
+    <Panel hand="c" span={12} className={GAP_BELOW_ASK}>
       {/* The heading IS the way through, opened in its own tab: a reader here
           came to scan a site, and the board should not take the page from them. */}
       <PanelHead

--- a/apps/console/src/features/report/ConsoleReport.tsx
+++ b/apps/console/src/features/report/ConsoleReport.tsx
@@ -12,7 +12,7 @@ import { ReadingSection } from './ReadingSection.js';
 import { SiteShot } from './SiteShot.js';
 
 const HANDOFF_OFFER =
-  'This is what a stranger with the URL can see. Log in for the full check, free.';
+  "This is what's visible to the public. Log in to perform code level check for free.";
 
 /**
  * Every reading of one site, under one verdict.
@@ -73,7 +73,7 @@ export function ConsoleReport({
    */
   if (everyOneFailed) {
     return (
-      <PanelGrid centred>
+      <PanelGrid fills>
         <Panel hand="c" red span={12}>
           <p className="pen-title">Nothing could be read</p>
           <p role="alert" className="mt-3 max-w-[62ch] text-body text-ink-2">

--- a/apps/console/src/features/report/Culprits.tsx
+++ b/apps/console/src/features/report/Culprits.tsx
@@ -90,7 +90,7 @@ export function Culprits({
       {pending ? (
         <Ruling />
       ) : top.length === 0 ? (
-        <p className="mt-4 text-body text-ink-2">Nothing was charged by any reading.</p>
+        <p className="mt-4 text-body text-ink-2">Didn't find any obvious giveaways.</p>
       ) : (
         <ol className="m-0 mt-4 list-none p-0">
           {top.map((culprit) => (

--- a/apps/console/src/tools/citecheck/WhyItMatters.tsx
+++ b/apps/console/src/tools/citecheck/WhyItMatters.tsx
@@ -1,4 +1,4 @@
-import { MarkLegible, Panel, PanelHead } from '@lumioguard/ui';
+import { GAP_BELOW_ASK, MarkLegible, Panel, PanelHead } from '@lumioguard/ui';
 
 /**
  * Why the reading is worth taking, on the page that offers it. Two short
@@ -6,7 +6,7 @@ import { MarkLegible, Panel, PanelHead } from '@lumioguard/ui';
  */
 export function WhyItMatters(): JSX.Element {
   return (
-    <Panel hand="c" span={12} className="mt-6">
+    <Panel hand="c" span={12} className={GAP_BELOW_ASK}>
       <PanelHead title="Be Found Wherever People Search" mark={<MarkLegible />} />
       <p className="mt-4 text-body leading-[1.6] text-ink-2">
         SEO and AI visibility help people discover your website when they are looking for a product,

--- a/apps/console/src/tools/leakpeek/CommonIssues.tsx
+++ b/apps/console/src/tools/leakpeek/CommonIssues.tsx
@@ -1,4 +1,4 @@
-import { MarkExposed, Panel, PanelHead } from '@lumioguard/ui';
+import { GAP_BELOW_ASK, MarkExposed, Panel, PanelHead } from '@lumioguard/ui';
 import { KNOWN_ISSUES, type KnownIssue } from './knownIssues.js';
 
 function Issue({ issue }: { readonly issue: KnownIssue }): JSX.Element {
@@ -19,7 +19,7 @@ function Issue({ issue }: { readonly issue: KnownIssue }): JSX.Element {
  */
 export function CommonIssues(): JSX.Element {
   return (
-    <Panel hand="c" span={12} className="mt-6">
+    <Panel hand="c" span={12} className={GAP_BELOW_ASK}>
       <PanelHead title="Common Security Failures in AI-Built Apps" mark={<MarkExposed />} />
       <ol className="m-0 mt-4 list-none p-0">
         {KNOWN_ISSUES.map((issue) => (

--- a/packages/ui/src/components/Panel.tsx
+++ b/packages/ui/src/components/Panel.tsx
@@ -61,23 +61,30 @@ export function Panel({
   return <section className={`pen-box flex flex-col ${modifiers}`}>{children}</section>;
 }
 
+/**
+ * The space between the ask and the panel under it, matching the space above
+ * the ask. The grid's own `gap-10` already adds 40px, so this carries the rest
+ * of that 128px: change one and change the other.
+ */
+export const GAP_BELOW_ASK = 'mt-[88px]';
+
 export interface PanelGridProps {
-  /** Before anything is asked, the entry takes the middle of the screen. */
-  readonly centred?: boolean;
+  /** Fill the height left under the masthead, so the colophon sits at the foot. */
+  readonly fills?: boolean;
   readonly className?: string;
   readonly children: ReactNode;
 }
 
 /** The notebook page: twelve columns on desktop, six below. */
 export function PanelGrid({
-  centred = false,
+  fills = false,
   className = '',
   children,
 }: PanelGridProps): JSX.Element {
   return (
     <div
-      className={`mx-auto grid w-full max-w-[76rem] grid-cols-6 gap-10 px-4 pt-5 lg:grid-cols-12 lg:px-[26px] lg:pt-[26px] ${
-        centred ? 'flex-1 content-center pb-10' : ''
+      className={`mx-auto grid w-full max-w-[76rem] grid-cols-6 gap-10 px-4 pt-24 lg:grid-cols-12 lg:px-[26px] lg:pt-[128px] ${
+        fills ? 'flex-1 content-start pb-10' : ''
       } ${className}`}
     >
       {children}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,6 @@
 export { ResolvingShot } from './components/ResolvingShot.js';
 export { Hint } from './components/Hint.js';
-export { Panel, PanelGrid, PanelHead } from './components/Panel.js';
+export { GAP_BELOW_ASK, Panel, PanelGrid, PanelHead } from './components/Panel.js';
 export type {
   Hand,
   PanelProps,


### PR DESCRIPTION
## Spacing

The gap under the masthead was an accident of content height. `PanelGrid` used
`flex-1 content-center`, so a page that overflowed the viewport got the grid's
padding (26px) and one that fitted got the leftover space (123px on `/scan`).
Same component, same class, four different gaps.

It is now `content-start` with an explicit top padding, so it cannot drift
again, and the interval above the ask and the interval below it are the same
number: **128px**, on every path.

Measured in the live DOM at 1707px, after the change:

| Page | rule to ask | ask to box below |
|---|---|---|
| `/ai-slop-check` | 128 | 128 |
| `/security-check` | 128 | 128 |
| `/seo-ai-visibility-check` | 128 | 128 |
| `/scan` | 128 | - |
| `/` | 128 | - |

Two things worth knowing:

- `centred` is renamed `fills`. A prop called `centred` that no longer centres
  is a trap for whoever reads it next.
- The lower gap is the grid's own `gap-10` plus a margin, two numbers that have
  to agree to make 128. They live together as `GAP_BELOW_ASK` beside the grid
  that supplies the other half, rather than as three copies of a magic number in
  three feature folders.

Below `lg` the top gap is `pt-24` (96px) while the lower one stays 128px. That
asymmetry is deliberate for now and only shows on narrow screens; it was not
measured, because the local browser would not resize.

## Copy

- "Nothing was charged by any reading." becomes "Didn't find any obvious
  giveaways."
- The hand-off offer becomes "This is what's visible to the public. Log in to
  perform code level check for free."

## Verified

`pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green. Layout
detector clean over every changed file. No horizontal overflow on any path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiMGHCDBKFgRLAxW1GL3e8