### PR TITLE
feat(console): report the hand-off click, on the marketing site's own event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ packages/shared                 wire contracts (zod) and shared domain vocabular
 packages/design-tokens          colour, type, radii, elevation, as a Tailwind plugin
 packages/ui                     the drawn surface: components, theme, stylesheet
 packages/api-core               transport, target resolution, reading hand-off
-packages/web-core               browser-side transport and scan state
+packages/web-core               browser-side transport, scan state and analytics
 tools/<tool>/core               detection engine. No I/O
 tools/<tool>/api                Cloudflare Worker over hono
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ packages/            what every tool shares
   design-tokens/     colour, type, spacing, radii → a Tailwind plugin
   ui/                the drawn surface: components, theme, stylesheet
   api-core/          transport and target resolution for a tool's Worker
-  web-core/          browser-side transport and scan state
+  web-core/          browser-side transport, scan state and analytics
 tools/<tool>/
   core/              the detection engine. Isomorphic, no I/O
   api/               Cloudflare Worker (Hono)
@@ -348,6 +348,39 @@ the markup:
 VITE_PUBLIC_SITE_URL=https://example.test pnpm --filter @lumioguard/console run build
 cat apps/console/dist/index.html apps/console/dist/robots.txt
 ```
+
+## Analytics
+
+Off by default and off in every fork: nothing loads and no request is made
+without `VITE_POSTHOG_KEY`. Set it and the console loads PostHog on its own
+chunk, configured exactly as the marketing site configures it, and reports four
+events.
+
+| Event | Sent when | Carries |
+|---|---|---|
+| `cta_click` | the hand-off button is clicked | `cta_text`, `cta_href`, `cta_location`, `tool_page`, `tools`, `score`, `tier`, `worst_tool` |
+| `scan_submit` | an address is submitted | `tool_page`, `tools`, `tool_count` |
+| `tools_select` | the picker changes | `tool_page`, `tools`, `tool_count` |
+| `report_view` | every reading has landed | `tool_page`, `tools`, `score`, `tier`, `worst_tool`, `failed_count` |
+
+**`cta_click` and its three `cta_` properties are the marketing site's own
+event**, kept name for name so one insight covers a click on either half of the
+site. That name lives in two repositories and no compiler can see both, so
+changing it here means changing `assets/consent.js` there. The same is true of
+the `lg-consent` key the banner writes and this console reads: the two halves of
+one site must not count differently, and same-origin is what carries the choice
+across.
+
+**No address is ever sent.** The site being read is somebody else's, and it
+reaches this app in the query, so `sanitize_properties` strips that parameter
+out of the URLs PostHog collects for itself. Sending it is a decision to take
+deliberately rather than one to arrive at by default. The hand-off's `cta_href`
+loses its query for the same reason: it carries the reading's site keys, which
+are handles to a report.
+
+Two guards, both of which must pass. The key is what a fork never has. The
+origin is `VITE_PUBLIC_SITE_URL`, so a preview deploy and a developer's laptop
+count nothing, which is the exclusion the marketing site makes by hostname.
 
 ## Local environment files
 

--- a/apps/console/.env.example
+++ b/apps/console/.env.example
@@ -44,3 +44,25 @@
 # the tool this app ships.
 # ---------------------------------------------------------------------------
 # VITE_PUBLIC_SITE_URL=https://lumioguard-readout.pages.dev
+
+# ---------------------------------------------------------------------------
+# Analytics, which is OFF unless a key is set. Nothing is loaded and no request
+# is made without one, so a fork ships a console that calls nobody.
+#
+# Configured to match `assets/consent.js` on the marketing site exactly: capture
+# starts cookielessly and an accepted cookie banner upgrades it, so the two
+# halves of one site never count differently. The choice is read from the
+# `lg-consent` key that banner writes, which only reaches here when both are
+# served from the same origin.
+#
+# VITE_PUBLIC_SITE_URL above is also the guard: analytics counts nothing at any
+# other origin, which is what keeps localhost and preview deploys out.
+# ---------------------------------------------------------------------------
+# VITE_POSTHOG_KEY=phc_...
+#
+# A first-party reverse proxy for PostHog. Its own host when unset.
+# VITE_POSTHOG_HOST=https://p.lumioguard.dev
+#
+# Only needed behind that proxy, where toolbar and dashboard links still need
+# the real UI host.
+# VITE_POSTHOG_UI_HOST=https://us.posthog.com

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -10,6 +10,7 @@ import {
   ThemeToggle,
   useTheme,
 } from '@lumioguard/ui';
+import { AnalyticsEvent, useAnalytics } from '@lumioguard/web-core';
 import type { ReactNode } from 'react';
 import { EXAMPLES, HEADLINE, PUBLISHER, beats } from './copy.js';
 import { LeaderboardPreview } from './features/leaderboard/LeaderboardPreview.js';
@@ -188,8 +189,33 @@ function Colophon(): JSX.Element {
 }
 
 export function App(): JSX.Element {
-  const { address, toolIds, pinned, chooser, board, open, select, clear } = useConsoleRoute();
+  const { address, toolIds, pinned, chooser, board, pageName, open, select, clear } =
+    useConsoleRoute();
   const tools = toolsById(TOOLS, toolIds);
+  const analytics = useAnalytics();
+
+  /**
+   * The two things a visitor does before a reading exists, reported with what
+   * they chose and never with what they typed. The address is somebody's site,
+   * and sending it is a decision to take deliberately rather than by default.
+   */
+  const scan = (next: string): void => {
+    analytics.capture(AnalyticsEvent.ScanSubmit, {
+      tool_page: pageName,
+      tools: toolIds.join(','),
+      tool_count: toolIds.length,
+    });
+    open(next);
+  };
+
+  const choose = (ids: readonly string[]): void => {
+    analytics.capture(AnalyticsEvent.ToolsSelect, {
+      tool_page: pageName,
+      tools: ids.join(','),
+      tool_count: ids.length,
+    });
+    select(ids);
+  };
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -200,19 +226,25 @@ export function App(): JSX.Element {
         <ChooseView />
       ) : address === null ? (
         <AskView
-          onScan={open}
+          onScan={scan}
           toolIds={toolIds}
-          onSelect={select}
+          onSelect={choose}
           pinned={pinned}
           // Each reading's own panel under the ask: the board is Slopmeter's,
           // the common issues are Leakpeek's, and the third has neither.
-          below={belowAsk(pinned?.id, open)}
+          below={belowAsk(pinned?.id, scan)}
         />
       ) : (
         // No picker here. What to read is asked once, before the reading; on the
         // report it was a control at the end of a page nobody scrolls to, for a
         // choice already made. `Read another site` is the way back to it.
-        <ConsoleReport key={address} address={address} tools={tools} onNewSite={clear} />
+        <ConsoleReport
+          key={address}
+          address={address}
+          tools={tools}
+          page={pageName}
+          onNewSite={clear}
+        />
       )}
       <Colophon />
     </div>

--- a/apps/console/src/analytics/__tests__/setup.test.ts
+++ b/apps/console/src/analytics/__tests__/setup.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { type AnalyticsEnv, analyticsConfig } from '../setup.js';
+
+const HERE = 'https://lumioguard.dev';
+const env = (over: AnalyticsEnv): AnalyticsEnv => ({ key: 'phc_test', publicSite: HERE, ...over });
+
+describe('analyticsConfig', () => {
+  // The switch a fork never throws. No key, no chunk fetched and no request made.
+  it('is off with no key', () => {
+    expect(analyticsConfig({ ...env({}), key: undefined }, HERE)).toBeNull();
+    expect(analyticsConfig({ ...env({}), key: '  ' }, HERE)).toBeNull();
+  });
+
+  // The exclusion the marketing site makes by hostname, made here against the
+  // address this build was made for: a preview deploy is not the product.
+  it('is off anywhere but the origin the build was made for', () => {
+    expect(analyticsConfig(env({}), 'https://lumioguard-readout.pages.dev')).toBeNull();
+    expect(analyticsConfig(env({}), 'http://127.0.0.1:5200')).toBeNull();
+  });
+
+  it('ignores the path on the public site, which is an origin question', () => {
+    expect(analyticsConfig(env({ publicSite: `${HERE}/tools` }), HERE)).not.toBeNull();
+  });
+
+  it('is on everywhere when no public site was configured', () => {
+    expect(analyticsConfig({ key: 'phc_test' }, 'http://127.0.0.1:5200')).not.toBeNull();
+  });
+
+  it('is off when the public site cannot be read as an address', () => {
+    expect(analyticsConfig(env({ publicSite: 'lumioguard.dev' }), HERE)).toBeNull();
+  });
+
+  it('carries the hosts, and the parameter that must never reach PostHog', () => {
+    expect(
+      analyticsConfig(
+        env({ host: 'https://p.lumioguard.dev', uiHost: 'https://us.posthog.com' }),
+        HERE,
+      ),
+    ).toEqual({
+      key: 'phc_test',
+      host: 'https://p.lumioguard.dev',
+      uiHost: 'https://us.posthog.com',
+      stripParams: ['site'],
+    });
+  });
+});

--- a/apps/console/src/analytics/setup.ts
+++ b/apps/console/src/analytics/setup.ts
@@ -1,0 +1,62 @@
+import { Analytics, type AnalyticsConfig, loadPostHog, readConsent } from '@lumioguard/web-core';
+import { SITE_PARAM } from '../features/scan/useConsoleRoute.js';
+
+/** The build-time settings this reads, as a value a test can hand over. */
+export interface AnalyticsEnv {
+  readonly key?: string | undefined;
+  readonly host?: string | undefined;
+  readonly uiHost?: string | undefined;
+  /** Where this build is meant to answer. Anywhere else counts nothing. */
+  readonly publicSite?: string | undefined;
+}
+
+/** A value that was actually configured, where blank and unset mean the same. */
+function configured(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed === undefined || trimmed === '' ? undefined : trimmed;
+}
+
+function sameOrigin(publicSite: string, here: string): boolean {
+  try {
+    return new URL(publicSite).origin === here;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The configuration, or null for no analytics at all.
+ *
+ * TWO conditions, and both matter. The key is what a fork never has, so a fork
+ * ships a console that loads nothing and calls nobody. The origin is what keeps
+ * a preview deploy and a developer's laptop out of the numbers, the same
+ * exclusion the marketing site makes by hostname, made here against the address
+ * this build already knows it was built for.
+ */
+export function analyticsConfig(env: AnalyticsEnv, origin: string): AnalyticsConfig | null {
+  const key = configured(env.key);
+  if (key === undefined) return null;
+
+  const publicSite = configured(env.publicSite);
+  if (publicSite !== undefined && !sameOrigin(publicSite, origin)) return null;
+
+  return {
+    key,
+    host: configured(env.host),
+    uiHost: configured(env.uiHost),
+    stripParams: [SITE_PARAM],
+  };
+}
+
+const ENV: AnalyticsEnv = {
+  key: import.meta.env.VITE_POSTHOG_KEY,
+  host: import.meta.env.VITE_POSTHOG_HOST,
+  uiHost: import.meta.env.VITE_POSTHOG_UI_HOST,
+  publicSite: import.meta.env.VITE_PUBLIC_SITE_URL,
+};
+
+/** Built once, in `main.tsx`, and handed to the tree through the provider. */
+export function consoleAnalytics(): Analytics {
+  const config = analyticsConfig(ENV, window.location.origin);
+  return config === null ? Analytics.off() : new Analytics(loadPostHog(config, readConsent()));
+}

--- a/apps/console/src/env.d.ts
+++ b/apps/console/src/env.d.ts
@@ -15,6 +15,14 @@ interface ImportMetaEnv {
   readonly VITE_LUMIOGUARD_APP_URL?: string;
   /** Where the wordmark points. Falls back to the app URL when unset. */
   readonly VITE_LUMIOGUARD_SITE_URL?: string;
+  /** Absent means no analytics: nothing is loaded and nothing is sent. */
+  readonly VITE_POSTHOG_KEY?: string;
+  /** A first-party proxy for PostHog. Its own host when unset. */
+  readonly VITE_POSTHOG_HOST?: string;
+  /** Only read behind a proxy, where toolbar links still need the real UI host. */
+  readonly VITE_POSTHOG_UI_HOST?: string;
+  /** Where this build answers. Analytics counts nothing at any other origin. */
+  readonly VITE_PUBLIC_SITE_URL?: string;
 }
 
 interface ImportMeta {

--- a/apps/console/src/features/report/ConsoleReport.tsx
+++ b/apps/console/src/features/report/ConsoleReport.tsx
@@ -1,5 +1,6 @@
 import { ReadingTier, consolidatedScore, readingBandFor } from '@lumioguard/shared';
 import { NextSteps, Panel, PanelGrid, ReadingState, Verdict } from '@lumioguard/ui';
+import type { EventProperties } from '@lumioguard/web-core';
 import { useState } from 'react';
 import { VERDICT_SCALE } from '../../theme/reading.js';
 import type { ToolDescriptor } from '../../tools/registry.js';
@@ -10,6 +11,7 @@ import { PageList } from './PageList.js';
 import { PageLists } from './PageLists.js';
 import { ReadingSection } from './ReadingSection.js';
 import { SiteShot } from './SiteShot.js';
+import { useReportView } from './useReportView.js';
 
 const HANDOFF_OFFER =
   "This is what's visible to the public. Log in to perform code level check for free.";
@@ -29,10 +31,13 @@ const HANDOFF_OFFER =
 export function ConsoleReport({
   address,
   tools,
+  page,
   onNewSite,
 }: {
   readonly address: string;
   readonly tools: readonly ToolDescriptor[];
+  /** Which document this report is being read on, for the events it sends. */
+  readonly page: string;
   readonly onNewSite: () => void;
 }): JSX.Element {
   const { readings, isReading } = useReadings(address, tools);
@@ -62,6 +67,26 @@ export function ConsoleReport({
   ];
 
   const everyOneFailed = readings.length > 0 && !isReading && landed.length === 0;
+  const tier = landed.length === 0 ? ReadingTier.Clean : readingBandFor(score).tier;
+
+  /**
+   * What this reading is, on every event the page sends. ONE object rather than
+   * a bag written out at each call: a property added to the hand-off and not to
+   * the report would leave two events describing one reading differently, and
+   * the rate measured between them quietly wrong.
+   */
+  const readingContext: EventProperties = {
+    tool_page: page,
+    tools: landed.map((reading) => reading.tool.id).join(','),
+    score,
+    tier,
+    worst_tool: worst?.tool.id ?? null,
+  };
+
+  useReportView(!isReading && landed.length > 0, {
+    ...readingContext,
+    failed_count: readings.length - landed.length,
+  });
 
   /**
    * Nothing read means NO VERDICT, not a clean one.
@@ -118,11 +143,17 @@ export function ConsoleReport({
         scale={VERDICT_SCALE}
         subject={address}
         score={score}
-        tier={landed.length === 0 ? ReadingTier.Clean : readingBandFor(score).tier}
+        tier={tier}
         waiting={isReading ? <ReadingState /> : undefined}
         onNewSite={onNewSite}
         actions={
-          landed.length === 0 ? undefined : <NextSteps offer={HANDOFF_OFFER} siteKey={siteKeys} />
+          landed.length === 0 ? undefined : (
+            <NextSteps
+              offer={HANDOFF_OFFER}
+              siteKey={siteKeys}
+              context={{ ...readingContext, cta_location: 'report_verdict' }}
+            />
+          )
         }
       />
 

--- a/apps/console/src/features/report/useReportView.ts
+++ b/apps/console/src/features/report/useReportView.ts
@@ -1,0 +1,27 @@
+import { AnalyticsEvent, type EventProperties, useAnalytics } from '@lumioguard/web-core';
+import { useEffect, useRef } from 'react';
+
+/**
+ * A finished report, reported ONCE.
+ *
+ * Latched rather than fired from a dependency edge: each reading lands on its
+ * own and re-runs the effect, and without the latch a slow third tool would
+ * report the same page again and double the denominator every hand-off rate is
+ * measured against.
+ *
+ * The properties are read from a ref rather than depended on, so rebuilding
+ * that object on a render cannot re-arm an effect whose only trigger is the
+ * moment the readings settled.
+ */
+export function useReportView(settled: boolean, properties: EventProperties): void {
+  const analytics = useAnalytics();
+  const latest = useRef(properties);
+  latest.current = properties;
+  const reported = useRef(false);
+
+  useEffect(() => {
+    if (!settled || reported.current) return;
+    reported.current = true;
+    analytics.capture(AnalyticsEvent.ReportView, latest.current);
+  }, [analytics, settled]);
+}

--- a/apps/console/src/features/scan/useConsoleRoute.ts
+++ b/apps/console/src/features/scan/useConsoleRoute.ts
@@ -1,8 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
-import { type ToolCopy, pageForPath } from '../../tools/catalogue.js';
+import { type ToolCopy, pageForPath, pageName } from '../../tools/catalogue.js';
 import { DEFAULT_TOOL_IDS, TOOLS } from '../../tools/index.js';
 
-const SITE = 'site';
+/**
+ * The address being read rides in the query, so it is in every URL the page
+ * records about itself. Exported because analytics has to strip it back out of
+ * the URLs PostHog collects on its own, and two spellings of it could not fail
+ * together.
+ */
+export const SITE_PARAM = 'site';
 const TOOLS_PARAM = 'tools';
 
 /** What the address bar is currently asking for. */
@@ -15,6 +21,8 @@ export interface ConsoleRoute {
   readonly chooser: boolean;
   /** The board scans nothing either: it ranks what has already been read. */
   readonly board: boolean;
+  /** This page's own name, for an event that has to say where it happened. */
+  readonly pageName: string;
 }
 
 /** The ways the page changes it, each writing history and re-reading. */
@@ -52,7 +60,8 @@ export function useConsoleRoute(): ConsoleRoute & RouteControls {
     pinned: route.pinned,
     chooser: route.chooser,
     board: route.board,
-    open: useCallback((next: string) => go((params) => params.set(SITE, next), true), [go]),
+    pageName: route.pageName,
+    open: useCallback((next: string) => go((params) => params.set(SITE_PARAM, next), true), [go]),
     // No scroll: changing the selection re-reads in place, and yanking the page
     // to the top on a checkbox loses whatever the reader was looking at.
     select: useCallback(
@@ -64,29 +73,37 @@ export function useConsoleRoute(): ConsoleRoute & RouteControls {
         }, false),
       [go],
     ),
-    clear: useCallback(() => go((params) => params.delete(SITE), true), [go]),
+    clear: useCallback(() => go((params) => params.delete(SITE_PARAM), true), [go]),
   };
 }
 
 function read(): ConsoleRoute {
   const params = new URLSearchParams(window.location.search);
 
-  const site = params.get(SITE);
+  const site = params.get(SITE_PARAM);
   const address = site === null || site.trim() === '' ? null : site;
 
   // A tool page runs its own reading and nothing else. The path wins over the
   // parameter: the URL is the promise the page made, and a `?tools=` on it
   // would quietly read something the heading never offered.
   const page = pageForPath(window.location.pathname);
+  const name = pageName(page);
   if (page.kind === 'tool') {
-    return { address, toolIds: [page.tool.id], pinned: page.tool, chooser: false, board: false };
+    return {
+      address,
+      toolIds: [page.tool.id],
+      pinned: page.tool,
+      chooser: false,
+      board: false,
+      pageName: name,
+    };
   }
 
   const chooser = page.kind === 'choose';
   const board = page.kind === 'leaderboard';
   const raw = params.get(TOOLS_PARAM);
   if (raw === null) {
-    return { address, toolIds: DEFAULT_TOOL_IDS, pinned: null, chooser, board };
+    return { address, toolIds: DEFAULT_TOOL_IDS, pinned: null, chooser, board, pageName: name };
   }
 
   const wanted = raw.split(',').map((id) => id.trim());
@@ -97,5 +114,6 @@ function read(): ConsoleRoute {
     pinned: null,
     chooser,
     board,
+    pageName: name,
   };
 }

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -1,6 +1,8 @@
+import { AnalyticsProvider } from '@lumioguard/web-core';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App.js';
+import { consoleAnalytics } from './analytics/setup.js';
 import '@lumioguard/ui/styles.css';
 
 const container = document.getElementById('root');
@@ -8,6 +10,8 @@ if (container === null) throw new Error('#root is missing from index.html');
 
 createRoot(container).render(
   <StrictMode>
-    <App />
+    <AnalyticsProvider analytics={consoleAnalytics()}>
+      <App />
+    </AnalyticsProvider>
   </StrictMode>,
 );

--- a/apps/console/src/tools/catalogue.ts
+++ b/apps/console/src/tools/catalogue.ts
@@ -107,6 +107,21 @@ export function pageForPath(pathname: string): ConsolePage {
   return { kind: 'choose' };
 }
 
+/**
+ * What a page is called where a name is wanted rather than a route: analytics,
+ * chiefly. A `Record` rather than a `switch`, so a fourth kind of page fails to
+ * compile here instead of reporting itself as `undefined`.
+ */
+const PAGE_NAME: Record<Exclude<ConsolePage['kind'], 'tool'>, string> = {
+  scan: SCAN_SLUG,
+  leaderboard: LEADERBOARD_SLUG,
+  choose: 'choose',
+};
+
+export function pageName(page: ConsolePage): string {
+  return page.kind === 'tool' ? page.tool.slug : PAGE_NAME[page.kind];
+}
+
 /** Where the board lives: under the reading it ranks. */
 export function leaderboardPath(): string {
   return `/${toolCopy(LEADERBOARD_TOOL).slug}/${LEADERBOARD_SLUG}`;

--- a/packages/ui/src/components/NextSteps.tsx
+++ b/packages/ui/src/components/NextSteps.tsx
@@ -1,14 +1,41 @@
+import { AnalyticsEvent, type EventProperties, useAnalytics } from '@lumioguard/web-core';
 import { fullAuditUrl } from '../integration/lumioguard.js';
+
+/**
+ * The label, in two halves because the brand is SET lowercase rather than typed
+ * that way, and in constants because the click reports the words on the button.
+ * A label that drifts from what was captured is a number about a button nobody
+ * can find.
+ */
+const LABEL_VERB = 'Log in to';
+const LABEL_BRAND = 'LumioGuard';
+
+/**
+ * The address, without its query. That query carries the reading's site keys,
+ * and a handle to somebody's report is not a thing to hand a third party.
+ */
+function withoutKeys(href: string): string {
+  try {
+    const url = new URL(href);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return href;
+  }
+}
 
 /** The hand-off, offer and button together. Renders nothing when it is off. */
 export function NextSteps({
   siteKey,
   offer,
+  context,
 }: {
   readonly siteKey: string | null | readonly (string | null)[];
   /** What the hand-off is worth, in this tool's own words. */
   readonly offer: string;
+  /** What the page around it knows, sent with the click. Never an address. */
+  readonly context?: EventProperties;
 }): JSX.Element | null {
+  const analytics = useAnalytics();
   const href = fullAuditUrl(siteKey);
   if (href === null) return null;
 
@@ -26,12 +53,19 @@ export function NextSteps({
         href={href}
         target="_blank"
         rel="noreferrer noopener"
+        onClick={() =>
+          analytics.capture(AnalyticsEvent.CtaClick, {
+            cta_text: `${LABEL_VERB} ${LABEL_BRAND}`,
+            cta_href: withoutKeys(href),
+            ...context,
+          })
+        }
         className="inline-flex shrink-0 items-center gap-[10px] self-start rounded-drawn-chip border-2 border-pen-300 bg-pen-400 px-5 py-[13px] font-sans text-16 font-semibold text-paper-raised no-underline transition-colors hover:bg-pen-300 sm:self-auto sm:px-6 lg:px-7 lg:py-[15px] lg:text-17"
       >
         {/* Set lowercase rather than typed lowercase, as the masthead does: the
             document keeps the real name, so a copy or a bookmark still spells
             it properly. */}
-        Log in to <span className="lowercase">LumioGuard</span>
+        {LABEL_VERB} <span className="lowercase">{LABEL_BRAND}</span>
         <svg
           viewBox="0 0 22 15"
           className="h-[15px] w-[22px] fill-none stroke-current"

--- a/packages/web-core/package.json
+++ b/packages/web-core/package.json
@@ -3,7 +3,7 @@
   "version": "0.11.0",
   "private": true,
   "type": "module",
-  "description": "Browser-side transport and scan state every tool's client shares.",
+  "description": "Browser-side transport, scan state and analytics every tool's client shares.",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
@@ -14,7 +14,8 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@lumioguard/shared": "workspace:*"
+    "@lumioguard/shared": "workspace:*",
+    "posthog-js": "^1.421.1"
   },
   "peerDependencies": {
     "react": "^18.3.1",

--- a/packages/web-core/src/analytics/Analytics.ts
+++ b/packages/web-core/src/analytics/Analytics.ts
@@ -1,0 +1,27 @@
+import type { AnalyticsEvent, EventProperties } from './events.js';
+
+/** The part of a loaded PostHog this console uses, and all a test needs to fake. */
+export interface CaptureSink {
+  capture(event: string, properties: EventProperties): void;
+}
+
+/**
+ * Where an event goes, which may be nowhere.
+ *
+ * The sink arrives as a PROMISE because loading PostHog is a network round
+ * trip that a click can beat. Resolving through it rather than queueing by
+ * hand keeps the order events were captured in and makes "analytics is off" a
+ * promise of null rather than a second code path.
+ */
+export class Analytics {
+  constructor(private readonly sink: Promise<CaptureSink | null>) {}
+
+  /** Off: nothing loads and every capture is dropped. */
+  static off(): Analytics {
+    return new Analytics(Promise.resolve(null));
+  }
+
+  capture(event: AnalyticsEvent, properties: EventProperties = {}): void {
+    void this.sink.then((sink) => sink?.capture(event, properties));
+  }
+}

--- a/packages/web-core/src/analytics/AnalyticsContext.tsx
+++ b/packages/web-core/src/analytics/AnalyticsContext.tsx
@@ -1,0 +1,19 @@
+import { type ReactNode, createContext, useContext } from 'react';
+import { Analytics } from './Analytics.js';
+
+/** Off, so a component rendered outside a provider captures nothing. */
+const AnalyticsContext = createContext<Analytics>(Analytics.off());
+
+export function AnalyticsProvider({
+  analytics,
+  children,
+}: {
+  readonly analytics: Analytics;
+  readonly children: ReactNode;
+}): JSX.Element {
+  return <AnalyticsContext.Provider value={analytics}>{children}</AnalyticsContext.Provider>;
+}
+
+export function useAnalytics(): Analytics {
+  return useContext(AnalyticsContext);
+}

--- a/packages/web-core/src/analytics/__tests__/Analytics.test.ts
+++ b/packages/web-core/src/analytics/__tests__/Analytics.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { Analytics, type CaptureSink } from '../Analytics.js';
+import { AnalyticsEvent, type EventProperties } from '../events.js';
+
+function recorder(): CaptureSink & { readonly sent: [string, EventProperties][] } {
+  const sent: [string, EventProperties][] = [];
+  return { sent, capture: (event, properties) => void sent.push([event, properties]) };
+}
+
+describe('Analytics', () => {
+  it('drops everything when it is off', async () => {
+    const analytics = Analytics.off();
+    analytics.capture(AnalyticsEvent.CtaClick, { cta_text: 'Log in to LumioGuard' });
+    await Promise.resolve();
+    expect(true).toBe(true);
+  });
+
+  // The click that matters lands before PostHog finishes loading often enough
+  // to matter: a hand-off captured into a sink that does not exist yet is the
+  // number this whole thing was added to see.
+  it('keeps an event captured before the sink arrived, in the order captured', async () => {
+    const sink = recorder();
+    let attach: (value: CaptureSink) => void = () => undefined;
+    const loading = new Promise<CaptureSink>((resolve) => {
+      attach = resolve;
+    });
+    const analytics = new Analytics(loading);
+
+    analytics.capture(AnalyticsEvent.ScanSubmit, { tools: 'leakpeek' });
+    analytics.capture(AnalyticsEvent.CtaClick, { cta_text: 'Log in to LumioGuard' });
+    expect(sink.sent).toHaveLength(0);
+
+    attach(sink);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(sink.sent.map(([event]) => event)).toEqual(['scan_submit', 'cta_click']);
+  });
+
+  it('sends an empty property bag rather than nothing', async () => {
+    const sink = recorder();
+    new Analytics(Promise.resolve(sink)).capture(AnalyticsEvent.ReportView);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sink.sent).toEqual([['report_view', {}]]);
+  });
+});

--- a/packages/web-core/src/analytics/__tests__/consent.test.ts
+++ b/packages/web-core/src/analytics/__tests__/consent.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { readConsent } from '../consent.js';
+
+const store = (value: string | null): Pick<Storage, 'getItem'> => ({ getItem: () => value });
+
+describe('readConsent', () => {
+  it('reads the shape the banner writes', () => {
+    expect(readConsent(store('{"analytics":true,"marketing":false}'))).toEqual({
+      analytics: true,
+      marketing: false,
+    });
+  });
+
+  it('still reads the two values that banner wrote before it had toggles', () => {
+    expect(readConsent(store('granted'))?.analytics).toBe(true);
+    expect(readConsent(store('denied'))?.analytics).toBe(false);
+  });
+
+  // Nothing stored is a visitor who has not been asked, which the caller treats
+  // as the site does: counted cookielessly, never as an acceptance.
+  it('answers null for nothing stored, and for anything unreadable', () => {
+    for (const raw of [null, '', 'not json', '[1,2]', '"granted"', 'null']) {
+      expect(readConsent(store(raw)), raw ?? 'null').toBeNull();
+    }
+  });
+
+  it('answers null when storage itself throws', () => {
+    expect(
+      readConsent({
+        getItem: () => {
+          throw new Error('blocked');
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('takes only a literal true as consent', () => {
+    expect(readConsent(store('{"analytics":"yes","marketing":1}'))).toEqual({
+      analytics: false,
+      marketing: false,
+    });
+  });
+});

--- a/packages/web-core/src/analytics/__tests__/redact.test.ts
+++ b/packages/web-core/src/analytics/__tests__/redact.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { scrubProperties } from '../redact.js';
+
+// PostHog collects $current_url without being asked, and this console carries
+// the site being read in the query. That address is somebody else's.
+describe('scrubProperties', () => {
+  it('strips the named parameter from every URL it finds', () => {
+    expect(
+      scrubProperties(
+        {
+          $current_url: 'https://lumioguard.dev/tools/?site=example.com&tools=leakpeek',
+          $referrer: 'https://lumioguard.dev/tools/scan?site=example.com',
+        },
+        ['site'],
+      ),
+    ).toEqual({
+      $current_url: 'https://lumioguard.dev/tools/?tools=leakpeek',
+      $referrer: 'https://lumioguard.dev/tools/scan',
+    });
+  });
+
+  it('leaves everything that is not a URL alone', () => {
+    const properties = { $pathname: '/tools/scan', score: 41, tools: 'leakpeek,citecheck' };
+    expect(scrubProperties(properties, ['site'])).toEqual(properties);
+  });
+
+  // Rewriting one it had no objection to would still change it: a bare origin
+  // comes back from the parser with a slash it was not sent with.
+  it('passes a URL carrying none of the parameters through as it was written', () => {
+    const properties = {
+      $current_url: 'https://lumioguard.dev',
+      $referrer: 'https://lumioguard.dev/tools/?tools=leakpeek',
+    };
+    expect(scrubProperties(properties, ['site'])).toEqual(properties);
+  });
+
+  it('leaves the properties untouched when there is nothing to strip', () => {
+    const properties = { $current_url: 'https://lumioguard.dev/tools/?site=example.com' };
+    expect(scrubProperties(properties, [])).toBe(properties);
+  });
+});

--- a/packages/web-core/src/analytics/consent.ts
+++ b/packages/web-core/src/analytics/consent.ts
@@ -1,0 +1,54 @@
+/**
+ * The cookie choice, as the site hosting this console wrote it.
+ *
+ * THE KEY AND ITS SHAPE ARE SHARED with `assets/consent.js` in the website
+ * repo, which is the only thing that writes them, and which no compiler here
+ * can see. Change one and change both.
+ */
+const CONSENT_KEY = 'lg-consent';
+
+export interface Consent {
+  readonly analytics: boolean;
+  readonly marketing: boolean;
+}
+
+/** Read-only on purpose: the banner on the marketing site is what writes this. */
+type ConsentStore = Pick<Storage, 'getItem'>;
+
+function safeStorage(): ConsentStore | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * What was chosen, or null where nothing has been. Null is NOT a refusal: a
+ * visitor who landed straight on a tool page has never been shown the banner,
+ * and is counted the way the site counts one who has not answered it yet.
+ */
+export function readConsent(storage: ConsentStore | null = safeStorage()): Consent | null {
+  let raw: string | null;
+  try {
+    raw = storage?.getItem(CONSENT_KEY) ?? null;
+  } catch {
+    return null;
+  }
+  if (raw === null || raw === '') return null;
+
+  // The two values the banner wrote before it grew per-category toggles.
+  if (raw === 'granted') return { analytics: true, marketing: false };
+  if (raw === 'denied') return { analytics: false, marketing: false };
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    // An array is an object too, and read as one it would answer "refused" for
+    // a value the banner cannot have written. Nothing readable is nothing asked.
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+    const record: Record<string, unknown> = { ...parsed };
+    return { analytics: record.analytics === true, marketing: record.marketing === true };
+  } catch {
+    return null;
+  }
+}

--- a/packages/web-core/src/analytics/events.ts
+++ b/packages/web-core/src/analytics/events.ts
@@ -1,0 +1,20 @@
+/**
+ * Every event this console sends, named once.
+ *
+ * `cta_click` IS THE MARKETING SITE'S OWN EVENT, with its three property names
+ * kept exactly, so one insight covers a click on either half and the console's
+ * extra properties ride along beside them. The rest are this console's own
+ * funnel and have no counterpart there. See `assets/consent.js` in the website
+ * repo, which is where the shared name is captured on the other side.
+ */
+export const AnalyticsEvent = {
+  CtaClick: 'cta_click',
+  ScanSubmit: 'scan_submit',
+  ToolsSelect: 'tools_select',
+  ReportView: 'report_view',
+} as const;
+
+export type AnalyticsEvent = (typeof AnalyticsEvent)[keyof typeof AnalyticsEvent];
+
+/** What travels with an event. Never an address, and never a site key. */
+export type EventProperties = Readonly<Record<string, string | number | boolean | null>>;

--- a/packages/web-core/src/analytics/posthog.ts
+++ b/packages/web-core/src/analytics/posthog.ts
@@ -1,0 +1,49 @@
+import type { CaptureSink } from './Analytics.js';
+import type { Consent } from './consent.js';
+import { scrubProperties } from './redact.js';
+
+export interface AnalyticsConfig {
+  /** The project key. Without one there is no analytics, which is the default. */
+  readonly key: string;
+  /** Usually a first-party reverse proxy. PostHog's own host when unset. */
+  readonly host?: string | undefined;
+  /** Only needed behind a proxy, where toolbar links still need the real UI host. */
+  readonly uiHost?: string | undefined;
+  /** Query parameters to strip from the URLs PostHog collects for itself. */
+  readonly stripParams?: readonly string[] | undefined;
+}
+
+/**
+ * PostHog, configured EXACTLY as the marketing site configures it in
+ * `assets/consent.js`: capture starts cookielessly from the first pageview and
+ * an accepted banner upgrades it, so a visitor is counted whether or not they
+ * have ever been asked. The two halves of one site must not count differently,
+ * so every option here is answered there too.
+ *
+ * Loaded on its own chunk, so a build with no key configured never fetches it.
+ */
+export async function loadPostHog(
+  config: AnalyticsConfig,
+  consent: Consent | null,
+): Promise<CaptureSink | null> {
+  const strip = config.stripParams ?? [];
+  try {
+    const { default: posthog } = await import('posthog-js');
+    posthog.init(config.key, {
+      api_host: config.host,
+      ui_host: config.uiHost,
+      defaults: '2026-05-30',
+      person_profiles: 'identified_only',
+      cookieless_mode: 'on_reject',
+      opt_out_capturing_by_default: true,
+      sanitize_properties: (properties) => scrubProperties(properties, strip),
+    });
+    if (consent?.analytics === true) posthog.opt_in_capturing();
+    else posthog.opt_out_capturing();
+    return posthog;
+  } catch {
+    // A reading is the product and analytics is not. Anything that stops
+    // PostHog loading, an ad blocker most often, leaves the console working.
+    return null;
+  }
+}

--- a/packages/web-core/src/analytics/redact.ts
+++ b/packages/web-core/src/analytics/redact.ts
@@ -1,0 +1,37 @@
+/**
+ * The scanned address out of every URL PostHog records by itself.
+ *
+ * `$current_url` and its siblings are collected without being asked for, and a
+ * console that carries the site being read in its query hands them over with
+ * it. Somebody else's address, typed into this box, is not a thing to give a
+ * third party.
+ */
+function scrubUrl(value: string, params: readonly string[]): string {
+  try {
+    const url = new URL(value);
+    // Untouched URLs pass through as they were written. Returning
+    // `url.toString()` regardless would normalise them, so a value nothing here
+    // objected to would still reach PostHog changed.
+    if (!params.some((param) => url.searchParams.has(param))) return value;
+    for (const param of params) url.searchParams.delete(param);
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+export function scrubProperties(
+  properties: Record<string, unknown>,
+  params: readonly string[],
+): Record<string, unknown> {
+  if (params.length === 0) return properties;
+  const scrubbed: Record<string, unknown> = { ...properties };
+  for (const [name, value] of Object.entries(scrubbed)) {
+    // The cheap test first: an event carries dozens of properties and most are
+    // not addresses, so parsing every one of them to find out is wasted work.
+    if (typeof value === 'string' && value.includes('://')) {
+      scrubbed[name] = scrubUrl(value, params);
+    }
+  }
+  return scrubbed;
+}

--- a/packages/web-core/src/index.ts
+++ b/packages/web-core/src/index.ts
@@ -1,3 +1,12 @@
 export { ApiClient, ScanApiError } from './api/ApiClient.js';
 export { useSiteScan } from './hooks/useSiteScan.js';
 export type { RunScan, SiteScanState } from './hooks/useSiteScan.js';
+export { Analytics } from './analytics/Analytics.js';
+export type { CaptureSink } from './analytics/Analytics.js';
+export { AnalyticsProvider, useAnalytics } from './analytics/AnalyticsContext.js';
+export { AnalyticsEvent } from './analytics/events.js';
+export type { EventProperties } from './analytics/events.js';
+export { readConsent } from './analytics/consent.js';
+export type { Consent } from './analytics/consent.js';
+export { loadPostHog } from './analytics/posthog.js';
+export type { AnalyticsConfig } from './analytics/posthog.js';

--- a/packages/web-core/tsconfig.json
+++ b/packages/web-core/tsconfig.json
@@ -7,5 +7,5 @@
     "types": ["vite/client"],
     "paths": { "@lumioguard/shared": ["../shared/src/index.ts"] }
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@lumioguard/shared':
         specifier: workspace:*
         version: link:../shared
+      posthog-js:
+        specifier: ^1.421.1
+        version: 1.421.1(@types/react@18.3.31)(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.18
@@ -1010,6 +1013,15 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@posthog/browser-common@0.6.0':
+    resolution: {integrity: sha512-d6yBE7VeoU3JTpaab3CaCoDCseh0Ytx7sTe0v2ZxhtHNxoKk7rdqr92+bUz9F1T2CuJO5/OTkes4HWT2VHNrTA==}
+
+  '@posthog/core@1.48.12':
+    resolution: {integrity: sha512-W/5d6QQD67Dq/Hhzg3lSG7fIXhbiiYGa/YwAoFI9iXKXDpaZkTmwDsEJAGPgTb2eb3lbLHXgGftuWGF2K6lU3g==}
+
+  '@posthog/types@1.407.0':
+    resolution: {integrity: sha512-7J/aFVi7JWFt/ekGVsMFvkTcADoE9MTNf1N9cpBSMUQ/SPLiBjbg386Fzk5OlgWG/u5OemBy4wlgD7YebqeppQ==}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -1210,6 +1222,9 @@ packages:
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -1321,6 +1336,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1351,6 +1369,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   electron-to-chromium@1.5.405:
     resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
@@ -1401,6 +1422,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1618,6 +1642,28 @@ packages:
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  posthog-js@1.421.1:
+    resolution: {integrity: sha512-hJMqfSxh9EpqM/yLVv7b+Wihgm2o9v/FJng3m1Ytf2i7miWOZTdibBeB8QPdZeuOK/zlvm4l2jkNcmKssh51cA==}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1848,6 +1894,12 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -2391,6 +2443,17 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@posthog/browser-common@0.6.0':
+    dependencies:
+      '@posthog/core': 1.48.12
+      '@posthog/types': 1.407.0
+
+  '@posthog/core@1.48.12':
+    dependencies:
+      '@posthog/types': 1.407.0
+
+  '@posthog/types@1.407.0': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.4':
@@ -2535,6 +2598,9 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@1.21.7))':
     dependencies:
       '@babel/core': 7.29.7
@@ -2661,6 +2727,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-js@3.50.0: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -2676,6 +2744,10 @@ snapshots:
   didyoumean@1.2.2: {}
 
   dlv@1.1.3: {}
+
+  dompurify@3.4.14:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.405: {}
 
@@ -2766,6 +2838,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.4.9: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -2931,6 +3005,28 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  posthog-js@1.421.1(@types/react@18.3.31)(react@18.3.1):
+    dependencies:
+      '@posthog/browser-common': 0.6.0
+      '@posthog/core': 1.48.12
+      '@posthog/types': 1.407.0
+      core-js: 3.50.0
+      dompurify: 3.4.14
+      fflate: 0.4.9
+      preact: 10.29.8
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
+    optionalDependencies:
+      '@types/react': 18.3.31
+      react: 18.3.1
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  preact@10.29.8: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -3226,6 +3322,10 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/tools/citecheck/README.md
+++ b/tools/citecheck/README.md
@@ -394,6 +394,7 @@ tools via `@lumioguard/ui`, `@lumioguard/api-core` and `@lumioguard/web-core`.
 | `LUMIOGUARD_API_BASE_URL` | api | unset (required alongside the secret) |
 | `VITE_CITECHECK_API_URL` | console | empty (the console proxies `/citecheck/api`) |
 | `VITE_LUMIOGUARD_APP_URL` | console | unset (no button, no offer, no wordmark) |
+| `VITE_POSTHOG_KEY` | console | unset (no analytics: nothing loads, nothing is sent) |
 
 All optional; see `api/.dev.vars.example` and `apps/console/.env.example`. Citecheck is a
 complete tool with none of them set. With `VITE_LUMIOGUARD_APP_URL` unset, which

--- a/tools/leakpeek/README.md
+++ b/tools/leakpeek/README.md
@@ -152,6 +152,7 @@ tools via `@lumioguard/ui`, `@lumioguard/api-core` and `@lumioguard/web-core`.
 | `LUMIOGUARD_API_BASE_URL` | api | unset (required alongside the secret) |
 | `VITE_LEAKPEEK_API_URL` | console | empty (the console proxies `/leakpeek/api`) |
 | `VITE_LUMIOGUARD_APP_URL` | console | unset (no button, no offer, no wordmark) |
+| `VITE_POSTHOG_KEY` | console | unset (no analytics: nothing loads, nothing is sent) |
 
 All optional; see `api/.dev.vars.example` and `apps/console/.env.example`. Leakpeek is a
 complete tool with none of them set. With `VITE_LUMIOGUARD_APP_URL` unset, which

--- a/tools/slopmeter/README.md
+++ b/tools/slopmeter/README.md
@@ -138,6 +138,7 @@ fixtures to make it pass.
 | `LUMIOGUARD_API_BASE_URL` | api | unset (required alongside the secret) |
 | `VITE_SLOPMETER_API_URL` | console | empty (the console proxies `/slopmeter/api`) |
 | `VITE_LUMIOGUARD_APP_URL` | console | unset (no button, no offer, no wordmark) |
+| `VITE_POSTHOG_KEY` | console | unset (no analytics: nothing loads, nothing is sent) |
 | `SLOPMETER_PARITY_ROOT` | tests | unset (the parity suite skips) |
 
 All optional; see `api/.dev.vars.example` and `apps/console/.env.example`. Slopmeter is a


### PR DESCRIPTION
The `/tools` console shipped no analytics at all, so the "Log in to LumioGuard"
button was invisible in PostHog. Every other page on the site loads
`assets/consent.js`; nothing under `tools/` did.

Copying that script in would not have fixed it: its click delegate matches
`a.btn` and `.nav-links a`, which this app's markup does not use, and the
console also deploys standalone where that file does not exist. So the console
loads PostHog itself, off by default and configured exactly as the marketing
site configures it.

## Events

`cta_click` is the marketing site's own event, name and `cta_` properties kept,
so existing insights pick it up unchanged. `scan_submit`, `tools_select` and
`report_view` are the console's own funnel, so the hand-off has a denominator.

## Off unless configured

Two guards, both must pass: `VITE_POSTHOG_KEY` (which a fork never has, and
without which the chunk is never fetched) and `VITE_PUBLIC_SITE_URL` matching
the origin, which keeps preview deploys and laptops out of the numbers.

## No address leaves the browser

PostHog collects `$current_url` unasked and this app carries the scanned site in
its query, so `sanitize_properties` strips that parameter. The hand-off's
`cta_href` loses its query too: it carries the reading's site keys.

## Verified

Run against a real reading with a local endpoint standing in for PostHog:
`report_view` and `cta_click` each fired once, `$current_url` arrived without
`?site=`, and an accepted `lg-consent` upgraded a cookieless visitor to a real
distinct id.

`cta_click` and the `lg-consent` key now live in two repositories with no
compiler over both; CONTRIBUTING.md and the website README both say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RsYDFtbQ1k2APj4XvBPA1