### PR TITLE
fix(ci): pass the analytics variables into the console build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,6 +119,12 @@ jobs:
           # on stderr. That is right for a fork and wrong for us, so the
           # variable is set on this repo.
           VITE_PUBLIC_SITE_URL: ${{ vars.VITE_PUBLIC_SITE_URL }}
+          # Analytics, off unless VITE_POSTHOG_KEY is set, which is what a fork
+          # gets. The origin above is the second guard: a build answering
+          # anywhere else counts nothing, so a preview deploy stays out.
+          VITE_POSTHOG_KEY: ${{ vars.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST }}
+          VITE_POSTHOG_UI_HOST: ${{ vars.VITE_POSTHOG_UI_HOST }}
         run: pnpm --filter @lumioguard/console run build
 
       - run: pnpm --filter @lumioguard/console run deploy


### PR DESCRIPTION
The repository variables existed and the workflow never read them, so a deploy
would have built the console with analytics off while everything looked fine.
That is the failure mode the comment right above this block already warns about
for the Worker origins.

Both guards still hold on their own. `VITE_POSTHOG_KEY` is unset for a fork, so
the chunk is never fetched and nothing is sent; `VITE_PUBLIC_SITE_URL` has to
match the origin, so a preview deploy counts nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RsYDFtbQ1k2APj4XvBPA1