### PR TITLE
feat(ui): name the tool in the hand-off link

### DIFF
--- a/apps/console/src/features/report/ConsoleReport.tsx
+++ b/apps/console/src/features/report/ConsoleReport.tsx
@@ -131,6 +131,8 @@ export function ConsoleReport({
             <NextSteps
               offer={HANDOFF_OFFER}
               siteKey={siteKeys}
+              // One tool's report names itself; a run of several is a full audit.
+              from={tools.length === 1 ? (tools[0]?.id ?? null) : null}
               context={{ ...readingContext, cta_location: 'report_verdict' }}
             />
           )

--- a/packages/ui/src/components/NextSteps.tsx
+++ b/packages/ui/src/components/NextSteps.tsx
@@ -16,17 +16,20 @@ const LABEL_BRAND = 'LumioGuard';
 /** Renders NOTHING when the LumioGuard integration is not configured. */
 export function NextSteps({
   siteKey,
+  from = null,
   offer,
   context,
 }: {
   readonly siteKey: string | null | readonly (string | null)[];
+  /** The tool this report belongs to, when it is one tool's. The app leads with it. */
+  readonly from?: string | null;
   /** What the hand-off is worth, in this tool's own words. */
   readonly offer: string;
   /** What the page around it knows, sent with the click. Never an address. */
   readonly context?: EventProperties;
 }): JSX.Element | null {
   const analytics = useAnalytics();
-  const href = fullAuditUrl(siteKey);
+  const href = fullAuditUrl(siteKey, from);
   if (href === null) return null;
 
   return (

--- a/packages/ui/src/integration/__tests__/lumioguard.test.ts
+++ b/packages/ui/src/integration/__tests__/lumioguard.test.ts
@@ -65,6 +65,15 @@ describe.skipIf(AUDIT_ORIGIN === null)('fullAuditUrl, with an app configured', (
     expect(url.searchParams.getAll('sitekey')).toEqual(['AAAAAA_BBBBBB_CCCCCC']);
   });
 
+  // The app leads with the tool the visitor is leaving, so one tool's report names
+  // itself. A console that ran several names none and the app shows them side by side.
+  it('names the tool the report belongs to, and only then', () => {
+    const named = new URL(fullAuditUrl('K7M2XQ', 'slopmeter') ?? '');
+    expect(named.searchParams.get('from')).toBe('slopmeter');
+    expect(named.searchParams.get('sitekey')).toBe('K7M2XQ');
+    expect(new URL(fullAuditUrl('K7M2XQ') ?? '').searchParams.has('from')).toBe(false);
+  });
+
   // The caller orders them, so the reading that set the verdict leads.
   it('puts the caller’s worst reading first', () => {
     const url = new URL(fullAuditUrl(['WORST1', 'BBBBBB']) ?? '');

--- a/packages/ui/src/integration/lumioguard.ts
+++ b/packages/ui/src/integration/lumioguard.ts
@@ -43,13 +43,21 @@ const KEY_JOINER = '_';
  * Never a sign-in path: that route has moved and every visitor landed on a 404. Keys
  * come from the readings, never derived from the address, or everyone who scanned a
  * host reaches one stranger's verdict. ORDER IS MEANING: the verdict's key leads.
+ *
+ * `from` names the tool the visitor is leaving, when the report is one tool's: the
+ * app leads with that reading and files the rest as other findings. A console that
+ * ran several tools names none, and the app shows them side by side.
  */
-export function fullAuditUrl(siteKeys: string | null | readonly (string | null)[]): string | null {
+export function fullAuditUrl(
+  siteKeys: string | null | readonly (string | null)[],
+  from: string | null = null,
+): string | null {
   if (AUDIT_ORIGIN === null) return null;
   const url = new URL('/', AUDIT_ORIGIN);
   const keys = (Array.isArray(siteKeys) ? siteKeys : [siteKeys]).filter(
     (key): key is string => typeof key === 'string' && key !== '',
   );
   if (keys.length > 0) url.searchParams.set('sitekey', keys.join(KEY_JOINER));
+  if (from) url.searchParams.set('from', from);
   return url.toString();
 }


### PR DESCRIPTION
## Why

LumioGuard's guest page now leads with the reading of the tool the visitor came from, and files the other tools' readings under "Other findings". It can tell a lone key came from the tool that minted it, but a report that names itself is explicit and survives the app adding more keys. The console's hand-off link now appends `from=<toolId>` when the report is one tool's, and omits it when several ran, which the app shows as a full audit.

## Verification

```text
pnpm typecheck && pnpm lint && pnpm test && pnpm build && pnpm rules:check
```

- [x] The complete gate passes.
- [x] Behaviour changes are reflected in the relevant README (the hand-off is documented in the app repo's `.documentation/guest-mode.md`; nothing here changes what a tool reads or scores).

## Fork behaviour

- [x] No LumioGuard address or integration appears unless it is configured: `fullAuditUrl` still answers null with no app origin, so `from` never renders alone.
- [x] No scanned address, reading key, secret, or target data reaches analytics: the click still reports `withoutQuery(href)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZWuwed4rfEZyw1XLjuGNA
